### PR TITLE
Upgrade Elastic base-tech version to 6.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The data sent to the StatsD server tries to be roughly equivalent to the [Indice
 
 | Elasticsearch  | Plugin         | Release date |
 | -------------- | -------------- | ------------ |
+| 6.8.0          | 6.8.0.0        | Jun 21, 2019 |
 | 6.6.1          | 6.6.1.0        | Mar 11, 2019 |
 | 6.5.0          | 6.5.0.0        | Jan 2,  2019 |
 | 6.4.3          | 6.4.3.0        | Jan 1,  2019 |
@@ -85,12 +86,12 @@ The plugin artifacts are published to Maven Central and Github. To install a pre
 From Github:
 
 ```
-./bin/elasticsearch-plugin install https://github.com/Automattic/elasticsearch-statsd-plugin/releases/download/6.6.1.0/elasticsearch-statsd-6.6.1.0.zip
+./bin/elasticsearch-plugin install https://github.com/Automattic/elasticsearch-statsd-plugin/releases/download/6.8.0.0/elasticsearch-statsd-6.8.0.0.zip
 ```
 
 From Maven Central:
 ```
-./bin/elasticsearch-plugin install http://repo1.maven.org/maven2/com/automattic/elasticsearch-statsd/6.6.1.0/elasticsearch-statsd-6.6.1.0.zip
+./bin/elasticsearch-plugin install http://repo1.maven.org/maven2/com/automattic/elasticsearch-statsd/6.8.0.0/elasticsearch-statsd-6.8.0.0.zip
 ```
 
 Change the version to match your ES version. For ES `x.y.z` the version is `x.y.z.0`
@@ -106,7 +107,7 @@ mvn clean package -Djava.security.policy=src/test/resources/plugin-security-test
 Once we have the artifact, install it with the following command:
 
 ```
-bin/elasticsearch-plugin install file:///absolute/path/to/current/dir/target/releases/elasticsearch-statsd-6.6.1.0.zip
+bin/elasticsearch-plugin install file:///absolute/path/to/current/dir/target/releases/elasticsearch-statsd-6.8.0.0.zip
 ```
 
 ## Installation Elasticsearch 5.x

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.automattic</groupId>
     <artifactId>elasticsearch-statsd</artifactId>
-    <version>6.6.1.0</version>
+    <version>6.8.0.0</version>
     <packaging>jar</packaging>
 
     <name>elasticsearch-statsd</name>
@@ -46,7 +46,7 @@
     </developers>
 
     <properties>
-        <elasticsearch.version>6.6.1</elasticsearch.version>
+        <elasticsearch.version>6.8.0</elasticsearch.version>
         <junit.version>4.12</junit.version>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Local build output:
```
ph@ph-VirtualBox:~/projects/elasticsearch-statsd-plugin$ mvn clean package -Djava.security.policy=src/test/resources/plugin-security-test.policy -Dtests.gradle=false
[INFO] Scanning for projects...
[INFO] 
[INFO] ----------------< com.automattic:elasticsearch-statsd >-----------------
[INFO] Building elasticsearch-statsd 6.8.0.0
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ elasticsearch-statsd ---
[INFO] Deleting /home/ph/projects/elasticsearch-statsd-plugin/target
[INFO] 
[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ elasticsearch-statsd ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] skip non existing resourceDirectory /home/ph/projects/elasticsearch-statsd-plugin/src/main/resources
[INFO] 
[INFO] --- maven-compiler-plugin:2.3.2:compile (default-compile) @ elasticsearch-statsd ---
[INFO] Compiling 7 source files to /home/ph/projects/elasticsearch-statsd-plugin/target/classes
[INFO] 
[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ elasticsearch-statsd ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 2 resources
[INFO] 
[INFO] --- maven-compiler-plugin:2.3.2:testCompile (default-testCompile) @ elasticsearch-statsd ---
[INFO] Compiling 3 source files to /home/ph/projects/elasticsearch-statsd-plugin/target/test-classes
[INFO] 
[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ elasticsearch-statsd ---
[INFO] Surefire report directory: /home/ph/projects/elasticsearch-statsd-plugin/target/surefire-reports

-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running com.automattic.elasticsearch.statsd.test.StatsdPluginIntegrationTest
[2019-06-21T11:37:38,256][INFO ][c.a.e.s.t.StatsdPluginIntegrationTest] [testThatIndexingResultsInMonitoring] before test
[2019-06-21T11:37:38,272][INFO ][c.a.e.s.t.StatsdPluginIntegrationTest] [testThatIndexingResultsInMonitoring] [StatsdPluginIntegrationTest#testThatIndexingResultsInMonitoring]: setting up test
[2019-06-21T11:37:38,346][INFO ][o.e.t.InternalTestCluster] [testThatIndexingResultsInMonitoring] Setup InternalTestCluster [SUITE-CHILD_VM=[0]-CLUSTER_SEED=[2475364676174221520]-HASH=[A67531AFDD18]-cluster] with seed [225A430ED4EA10D0] using [3] dedicated masters, [3] (data) nodes and [0] coord only nodes (min_master_nodes are [auto-managed])
[2019-06-21T11:37:39,196][INFO ][o.e.e.NodeEnvironment    ] [testThatIndexingResultsInMonitoring] using [2] data paths, mounts [[/ (/dev/sda1)]], net usable_space [1.3gb], net total_space [29.3gb], types [ext4]
[2019-06-21T11:37:39,204][INFO ][o.e.e.NodeEnvironment    ] [testThatIndexingResultsInMonitoring] heap size [1.2gb], compressed ordinary object pointers [true]
[2019-06-21T11:37:39,223][INFO ][o.e.n.Node               ] [testThatIndexingResultsInMonitoring] node name [node_sm0], node ID [9mLcvpOrSYOY8tzGqd4M1g]
[2019-06-21T11:37:39,233][INFO ][o.e.n.Node               ] [testThatIndexingResultsInMonitoring] version[6.8.0], pid[28602], build[unknown/unknown/65b6179/2019-05-15T20:06:13.172855Z], OS[Linux/4.18.0-20-generic/amd64], JVM[Oracle Corporation/OpenJDK 64-Bit Server VM/1.8.0_212/25.212-b03]
[2019-06-21T11:37:39,256][INFO ][o.e.n.Node               ] [testThatIndexingResultsInMonitoring] JVM arguments []
[2019-06-21T11:37:39,290][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] no modules loaded
[2019-06-21T11:37:39,308][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [com.automattic.elasticsearch.plugin.StatsdPlugin]
[2019-06-21T11:37:39,311][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.index.MockEngineFactoryPlugin]
[2019-06-21T11:37:39,314][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.index.mapper.MockFieldFilterPlugin]
[2019-06-21T11:37:39,320][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.node.NodeMocksPlugin]
[2019-06-21T11:37:39,323][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.search.MockSearchService$TestPlugin]
[2019-06-21T11:37:39,325][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.test.ESIntegTestCase$AssertActionNamePlugin]
[2019-06-21T11:37:39,328][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.test.ESIntegTestCase$TestSeedPlugin]
[2019-06-21T11:37:39,329][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.test.discovery.TestZenDiscovery$TestPlugin]
[2019-06-21T11:37:39,329][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.test.store.MockFSIndexStore$TestPlugin]
[2019-06-21T11:37:39,330][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.test.transport.MockTransportService$TestPlugin]
[2019-06-21T11:37:39,342][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.transport.MockTcpTransportPlugin]
[2019-06-21T11:37:40,237][WARN ][o.e.d.c.s.Settings       ] [testThatIndexingResultsInMonitoring] [http.enabled] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version.
[2019-06-21T11:37:40,254][WARN ][o.e.d.c.s.Settings       ] [testThatIndexingResultsInMonitoring] [http.pipelining] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version.
[2019-06-21T11:37:41,803][INFO ][o.e.d.DiscoveryModule    ] [testThatIndexingResultsInMonitoring] using discovery type [test-zen] and host providers [settings, file]
[2019-06-21T11:37:42,783][INFO ][o.e.n.Node               ] [testThatIndexingResultsInMonitoring] initialized
[2019-06-21T11:37:42,813][INFO ][o.e.e.NodeEnvironment    ] [testThatIndexingResultsInMonitoring] using [2] data paths, mounts [[/ (/dev/sda1)]], net usable_space [1.3gb], net total_space [29.3gb], types [ext4]
[2019-06-21T11:37:42,818][INFO ][o.e.e.NodeEnvironment    ] [testThatIndexingResultsInMonitoring] heap size [1.2gb], compressed ordinary object pointers [true]
[2019-06-21T11:37:42,825][INFO ][o.e.n.Node               ] [testThatIndexingResultsInMonitoring] node name [node_sm1], node ID [gkaIFYk4TDyw2zAE9LqX7g]
[2019-06-21T11:37:42,828][INFO ][o.e.n.Node               ] [testThatIndexingResultsInMonitoring] version[6.8.0], pid[28602], build[unknown/unknown/65b6179/2019-05-15T20:06:13.172855Z], OS[Linux/4.18.0-20-generic/amd64], JVM[Oracle Corporation/OpenJDK 64-Bit Server VM/1.8.0_212/25.212-b03]
[2019-06-21T11:37:42,835][INFO ][o.e.n.Node               ] [testThatIndexingResultsInMonitoring] JVM arguments []
[2019-06-21T11:37:42,840][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] no modules loaded
[2019-06-21T11:37:42,843][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [com.automattic.elasticsearch.plugin.StatsdPlugin]
[2019-06-21T11:37:42,845][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.index.MockEngineFactoryPlugin]
[2019-06-21T11:37:42,845][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.index.mapper.MockFieldFilterPlugin]
[2019-06-21T11:37:42,851][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.node.NodeMocksPlugin]
[2019-06-21T11:37:42,852][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.search.MockSearchService$TestPlugin]
[2019-06-21T11:37:42,854][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.test.ESIntegTestCase$AssertActionNamePlugin]
[2019-06-21T11:37:42,856][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.test.ESIntegTestCase$TestSeedPlugin]
[2019-06-21T11:37:42,867][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.test.discovery.TestZenDiscovery$TestPlugin]
[2019-06-21T11:37:42,867][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.test.store.MockFSIndexStore$TestPlugin]
[2019-06-21T11:37:42,868][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.test.transport.MockTransportService$TestPlugin]
[2019-06-21T11:37:42,868][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.transport.MockTcpTransportPlugin]
[2019-06-21T11:37:42,963][INFO ][o.e.d.DiscoveryModule    ] [testThatIndexingResultsInMonitoring] using discovery type [test-zen] and host providers [settings, file]
[2019-06-21T11:37:43,127][INFO ][o.e.n.Node               ] [testThatIndexingResultsInMonitoring] initialized
[2019-06-21T11:37:43,153][INFO ][o.e.e.NodeEnvironment    ] [testThatIndexingResultsInMonitoring] using [2] data paths, mounts [[/ (/dev/sda1)]], net usable_space [1.3gb], net total_space [29.3gb], types [ext4]
[2019-06-21T11:37:43,159][INFO ][o.e.e.NodeEnvironment    ] [testThatIndexingResultsInMonitoring] heap size [1.2gb], compressed ordinary object pointers [true]
[2019-06-21T11:37:43,166][INFO ][o.e.n.Node               ] [testThatIndexingResultsInMonitoring] node name [node_sm2], node ID [iQGbf2jpRUqidirSGmOd0Q]
[2019-06-21T11:37:43,170][INFO ][o.e.n.Node               ] [testThatIndexingResultsInMonitoring] version[6.8.0], pid[28602], build[unknown/unknown/65b6179/2019-05-15T20:06:13.172855Z], OS[Linux/4.18.0-20-generic/amd64], JVM[Oracle Corporation/OpenJDK 64-Bit Server VM/1.8.0_212/25.212-b03]
[2019-06-21T11:37:43,177][INFO ][o.e.n.Node               ] [testThatIndexingResultsInMonitoring] JVM arguments []
[2019-06-21T11:37:43,182][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] no modules loaded
[2019-06-21T11:37:43,189][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [com.automattic.elasticsearch.plugin.StatsdPlugin]
[2019-06-21T11:37:43,207][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.index.MockEngineFactoryPlugin]
[2019-06-21T11:37:43,207][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.index.mapper.MockFieldFilterPlugin]
[2019-06-21T11:37:43,208][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.node.NodeMocksPlugin]
[2019-06-21T11:37:43,208][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.search.MockSearchService$TestPlugin]
[2019-06-21T11:37:43,209][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.test.ESIntegTestCase$AssertActionNamePlugin]
[2019-06-21T11:37:43,209][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.test.ESIntegTestCase$TestSeedPlugin]
[2019-06-21T11:37:43,213][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.test.discovery.TestZenDiscovery$TestPlugin]
[2019-06-21T11:37:43,217][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.test.store.MockFSIndexStore$TestPlugin]
[2019-06-21T11:37:43,228][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.test.transport.MockTransportService$TestPlugin]
[2019-06-21T11:37:43,230][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.transport.MockTcpTransportPlugin]
[2019-06-21T11:37:43,369][INFO ][o.e.d.DiscoveryModule    ] [testThatIndexingResultsInMonitoring] using discovery type [test-zen] and host providers [settings, file]
[2019-06-21T11:37:43,500][INFO ][o.e.n.Node               ] [testThatIndexingResultsInMonitoring] initialized
[2019-06-21T11:37:43,562][INFO ][o.e.e.NodeEnvironment    ] [testThatIndexingResultsInMonitoring] using [2] data paths, mounts [[/ (/dev/sda1)]], net usable_space [1.3gb], net total_space [29.3gb], types [ext4]
[2019-06-21T11:37:43,575][INFO ][o.e.e.NodeEnvironment    ] [testThatIndexingResultsInMonitoring] heap size [1.2gb], compressed ordinary object pointers [true]
[2019-06-21T11:37:43,587][INFO ][o.e.n.Node               ] [testThatIndexingResultsInMonitoring] node name [node_sd3], node ID [dfQYD9HKRnCVFJcY0yiusA]
[2019-06-21T11:37:43,593][INFO ][o.e.n.Node               ] [testThatIndexingResultsInMonitoring] version[6.8.0], pid[28602], build[unknown/unknown/65b6179/2019-05-15T20:06:13.172855Z], OS[Linux/4.18.0-20-generic/amd64], JVM[Oracle Corporation/OpenJDK 64-Bit Server VM/1.8.0_212/25.212-b03]
[2019-06-21T11:37:43,599][INFO ][o.e.n.Node               ] [testThatIndexingResultsInMonitoring] JVM arguments []
[2019-06-21T11:37:43,603][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] no modules loaded
[2019-06-21T11:37:43,605][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [com.automattic.elasticsearch.plugin.StatsdPlugin]
[2019-06-21T11:37:43,606][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.index.MockEngineFactoryPlugin]
[2019-06-21T11:37:43,608][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.index.mapper.MockFieldFilterPlugin]
[2019-06-21T11:37:43,609][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.node.NodeMocksPlugin]
[2019-06-21T11:37:43,609][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.search.MockSearchService$TestPlugin]
[2019-06-21T11:37:43,610][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.test.ESIntegTestCase$AssertActionNamePlugin]
[2019-06-21T11:37:43,619][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.test.ESIntegTestCase$TestSeedPlugin]
[2019-06-21T11:37:43,620][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.test.discovery.TestZenDiscovery$TestPlugin]
[2019-06-21T11:37:43,622][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.test.store.MockFSIndexStore$TestPlugin]
[2019-06-21T11:37:43,622][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.test.transport.MockTransportService$TestPlugin]
[2019-06-21T11:37:43,623][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.transport.MockTcpTransportPlugin]
[2019-06-21T11:37:43,769][INFO ][o.e.d.DiscoveryModule    ] [testThatIndexingResultsInMonitoring] using discovery type [test-zen] and host providers [settings, file]
[2019-06-21T11:37:43,939][INFO ][o.e.n.Node               ] [testThatIndexingResultsInMonitoring] initialized
[2019-06-21T11:37:44,005][INFO ][o.e.e.NodeEnvironment    ] [testThatIndexingResultsInMonitoring] using [2] data paths, mounts [[/ (/dev/sda1)]], net usable_space [1.3gb], net total_space [29.3gb], types [ext4]
[2019-06-21T11:37:44,017][INFO ][o.e.e.NodeEnvironment    ] [testThatIndexingResultsInMonitoring] heap size [1.2gb], compressed ordinary object pointers [true]
[2019-06-21T11:37:44,027][INFO ][o.e.n.Node               ] [testThatIndexingResultsInMonitoring] node name [node_sd4], node ID [nolVJCRtRIywePi6dR04_A]
[2019-06-21T11:37:44,038][INFO ][o.e.n.Node               ] [testThatIndexingResultsInMonitoring] version[6.8.0], pid[28602], build[unknown/unknown/65b6179/2019-05-15T20:06:13.172855Z], OS[Linux/4.18.0-20-generic/amd64], JVM[Oracle Corporation/OpenJDK 64-Bit Server VM/1.8.0_212/25.212-b03]
[2019-06-21T11:37:44,050][INFO ][o.e.n.Node               ] [testThatIndexingResultsInMonitoring] JVM arguments []
[2019-06-21T11:37:44,051][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] no modules loaded
[2019-06-21T11:37:44,052][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [com.automattic.elasticsearch.plugin.StatsdPlugin]
[2019-06-21T11:37:44,057][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.index.MockEngineFactoryPlugin]
[2019-06-21T11:37:44,059][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.index.mapper.MockFieldFilterPlugin]
[2019-06-21T11:37:44,060][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.node.NodeMocksPlugin]
[2019-06-21T11:37:44,064][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.search.MockSearchService$TestPlugin]
[2019-06-21T11:37:44,064][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.test.ESIntegTestCase$AssertActionNamePlugin]
[2019-06-21T11:37:44,065][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.test.ESIntegTestCase$TestSeedPlugin]
[2019-06-21T11:37:44,070][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.test.discovery.TestZenDiscovery$TestPlugin]
[2019-06-21T11:37:44,072][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.test.store.MockFSIndexStore$TestPlugin]
[2019-06-21T11:37:44,072][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.test.transport.MockTransportService$TestPlugin]
[2019-06-21T11:37:44,073][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.transport.MockTcpTransportPlugin]
[2019-06-21T11:37:44,146][INFO ][o.e.d.DiscoveryModule    ] [testThatIndexingResultsInMonitoring] using discovery type [test-zen] and host providers [settings, file]
[2019-06-21T11:37:44,218][INFO ][o.e.n.Node               ] [testThatIndexingResultsInMonitoring] initialized
[2019-06-21T11:37:44,252][INFO ][o.e.e.NodeEnvironment    ] [testThatIndexingResultsInMonitoring] using [2] data paths, mounts [[/ (/dev/sda1)]], net usable_space [1.3gb], net total_space [29.3gb], types [ext4]
[2019-06-21T11:37:44,255][INFO ][o.e.e.NodeEnvironment    ] [testThatIndexingResultsInMonitoring] heap size [1.2gb], compressed ordinary object pointers [true]
[2019-06-21T11:37:44,260][INFO ][o.e.n.Node               ] [testThatIndexingResultsInMonitoring] node name [node_sd5], node ID [BKRP-ZBsQTyr8oAE7yCU5A]
[2019-06-21T11:37:44,270][INFO ][o.e.n.Node               ] [testThatIndexingResultsInMonitoring] version[6.8.0], pid[28602], build[unknown/unknown/65b6179/2019-05-15T20:06:13.172855Z], OS[Linux/4.18.0-20-generic/amd64], JVM[Oracle Corporation/OpenJDK 64-Bit Server VM/1.8.0_212/25.212-b03]
[2019-06-21T11:37:44,273][INFO ][o.e.n.Node               ] [testThatIndexingResultsInMonitoring] JVM arguments []
[2019-06-21T11:37:44,274][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] no modules loaded
[2019-06-21T11:37:44,276][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [com.automattic.elasticsearch.plugin.StatsdPlugin]
[2019-06-21T11:37:44,278][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.index.MockEngineFactoryPlugin]
[2019-06-21T11:37:44,279][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.index.mapper.MockFieldFilterPlugin]
[2019-06-21T11:37:44,280][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.node.NodeMocksPlugin]
[2019-06-21T11:37:44,280][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.search.MockSearchService$TestPlugin]
[2019-06-21T11:37:44,281][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.test.ESIntegTestCase$AssertActionNamePlugin]
[2019-06-21T11:37:44,281][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.test.ESIntegTestCase$TestSeedPlugin]
[2019-06-21T11:37:44,282][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.test.discovery.TestZenDiscovery$TestPlugin]
[2019-06-21T11:37:44,287][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.test.store.MockFSIndexStore$TestPlugin]
[2019-06-21T11:37:44,291][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.test.transport.MockTransportService$TestPlugin]
[2019-06-21T11:37:44,302][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.transport.MockTcpTransportPlugin]
[2019-06-21T11:37:44,428][INFO ][o.e.d.DiscoveryModule    ] [testThatIndexingResultsInMonitoring] using discovery type [test-zen] and host providers [settings, file]
[2019-06-21T11:37:44,503][INFO ][o.e.n.Node               ] [testThatIndexingResultsInMonitoring] initialized
[2019-06-21T11:37:44,555][INFO ][o.e.n.Node               ] [integ_6] starting ...
[2019-06-21T11:37:44,561][INFO ][c.a.e.s.StatsdService    ] [integ_6] StatsD reporting triggered every [1s] to host [localhost:12345] with metric prefix [myhost5]
[2019-06-21T11:37:44,567][INFO ][o.e.n.Node               ] [integ_1] starting ...
[2019-06-21T11:37:44,566][INFO ][o.e.n.Node               ] [integ_2] starting ...
[2019-06-21T11:37:44,570][INFO ][o.e.n.Node               ] [integ_3] starting ...
[2019-06-21T11:37:44,565][INFO ][o.e.n.Node               ] [integ_4] starting ...
[2019-06-21T11:37:44,564][INFO ][o.e.n.Node               ] [integ_5] starting ...
[2019-06-21T11:37:44,573][INFO ][c.a.e.s.StatsdService    ] [node_sd5] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,580][INFO ][c.a.e.s.StatsdService    ] [integ_1] StatsD reporting triggered every [1s] to host [localhost:12345] with metric prefix [myhost0]
[2019-06-21T11:37:44,584][INFO ][c.a.e.s.StatsdService    ] [node_sd5] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,583][INFO ][c.a.e.s.StatsdService    ] [node_sm0] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,611][INFO ][c.a.e.s.StatsdService    ] [node_sm1] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,601][INFO ][c.a.e.s.StatsdService    ] [integ_2] StatsD reporting triggered every [1s] to host [localhost:12345] with metric prefix [myhost1]
[2019-06-21T11:37:44,596][INFO ][c.a.e.s.StatsdService    ] [node_sm2] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,596][INFO ][c.a.e.s.StatsdService    ] [integ_3] StatsD reporting triggered every [1s] to host [localhost:12345] with metric prefix [myhost2]
[2019-06-21T11:37:44,595][INFO ][c.a.e.s.StatsdService    ] [node_sd5] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,590][INFO ][c.a.e.s.StatsdService    ] [node_sd3] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,590][INFO ][c.a.e.s.StatsdService    ] [integ_4] StatsD reporting triggered every [1s] to host [localhost:12345] with metric prefix [myhost3]
[2019-06-21T11:37:44,586][INFO ][c.a.e.s.StatsdService    ] [node_sd4] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,586][INFO ][c.a.e.s.StatsdService    ] [integ_5] StatsD reporting triggered every [1s] to host [localhost:12345] with metric prefix [myhost4]
[2019-06-21T11:37:44,646][INFO ][c.a.e.s.StatsdService    ] [node_sm0] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,649][INFO ][c.a.e.s.StatsdService    ] [node_sm1] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,654][INFO ][c.a.e.s.StatsdService    ] [node_sd3] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,654][INFO ][c.a.e.s.StatsdService    ] [node_sm2] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,664][INFO ][c.a.e.s.StatsdService    ] [node_sd4] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,664][INFO ][c.a.e.s.StatsdService    ] [node_sm0] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,665][INFO ][c.a.e.s.StatsdService    ] [node_sd5] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,665][INFO ][c.a.e.s.StatsdService    ] [node_sd3] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,666][INFO ][c.a.e.s.StatsdService    ] [node_sm1] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,682][INFO ][c.a.e.s.StatsdService    ] [node_sm1] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,684][INFO ][c.a.e.s.StatsdService    ] [node_sd3] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,684][INFO ][c.a.e.s.StatsdService    ] [node_sm2] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,684][INFO ][c.a.e.s.StatsdService    ] [node_sd4] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,684][INFO ][c.a.e.s.StatsdService    ] [node_sd5] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,684][INFO ][c.a.e.s.StatsdService    ] [node_sm0] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,697][INFO ][c.a.e.s.StatsdService    ] [node_sm0] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,697][INFO ][c.a.e.s.StatsdService    ] [node_sd5] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,698][INFO ][c.a.e.s.StatsdService    ] [node_sm1] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,698][INFO ][c.a.e.s.StatsdService    ] [node_sd3] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,697][INFO ][c.a.e.s.StatsdService    ] [node_sm2] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,697][INFO ][c.a.e.s.StatsdService    ] [node_sd4] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,722][INFO ][c.a.e.s.StatsdService    ] [node_sd5] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,723][INFO ][c.a.e.s.StatsdService    ] [node_sd4] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,723][INFO ][c.a.e.s.StatsdService    ] [node_sm2] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,731][INFO ][c.a.e.s.StatsdService    ] [node_sd3] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,731][INFO ][c.a.e.s.StatsdService    ] [node_sm1] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,731][INFO ][c.a.e.s.StatsdService    ] [node_sm0] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,742][INFO ][c.a.e.s.StatsdService    ] [node_sd3] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,742][INFO ][c.a.e.s.StatsdService    ] [node_sm1] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,742][INFO ][c.a.e.s.StatsdService    ] [node_sm0] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,752][INFO ][c.a.e.s.StatsdService    ] [node_sd4] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,752][INFO ][c.a.e.s.StatsdService    ] [node_sd5] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,753][INFO ][c.a.e.s.StatsdService    ] [node_sd3] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,753][INFO ][c.a.e.s.StatsdService    ] [node_sm1] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,753][INFO ][c.a.e.s.StatsdService    ] [node_sm0] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,763][INFO ][c.a.e.s.StatsdService    ] [node_sd5] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,764][INFO ][c.a.e.s.StatsdService    ] [node_sd3] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,764][INFO ][c.a.e.s.StatsdService    ] [node_sd4] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,764][INFO ][c.a.e.s.StatsdService    ] [node_sm1] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,766][INFO ][c.a.e.s.StatsdService    ] [node_sm0] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,777][INFO ][c.a.e.s.StatsdService    ] [node_sm2] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,777][INFO ][c.a.e.s.StatsdService    ] [node_sm1] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,776][INFO ][c.a.e.s.StatsdService    ] [node_sd4] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,775][INFO ][c.a.e.s.StatsdService    ] [node_sd3] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,774][INFO ][c.a.e.s.StatsdService    ] [node_sd5] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,794][INFO ][c.a.e.s.StatsdService    ] [node_sm2] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,794][INFO ][o.e.t.TransportService   ] [integ_6] publish_address {127.0.0.1:33651}, bound_addresses {[::1]:34677}, {127.0.0.1:33651}
[2019-06-21T11:37:44,793][INFO ][o.e.t.TransportService   ] [integ_4] publish_address {127.0.0.1:42637}, bound_addresses {[::1]:36997}, {127.0.0.1:42637}
[2019-06-21T11:37:44,792][INFO ][c.a.e.s.StatsdService    ] [node_sm0] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,795][INFO ][o.e.t.TransportService   ] [integ_1] publish_address {127.0.0.1:39595}, bound_addresses {[::1]:37579}, {127.0.0.1:39595}
[2019-06-21T11:37:44,799][INFO ][o.e.t.TransportService   ] [integ_3] publish_address {127.0.0.1:34709}, bound_addresses {[::1]:41459}, {127.0.0.1:34709}
[2019-06-21T11:37:44,805][INFO ][c.a.e.s.StatsdService    ] [node_sm1] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,805][INFO ][c.a.e.s.StatsdService    ] [node_sd4] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,806][INFO ][c.a.e.s.StatsdService    ] [node_sd3] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,806][INFO ][c.a.e.s.StatsdService    ] [node_sd5] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,807][INFO ][c.a.e.s.StatsdService    ] [node_sm2] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,808][INFO ][c.a.e.s.StatsdService    ] [node_sm0] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,816][INFO ][c.a.e.s.StatsdService    ] [node_sm1] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,816][INFO ][c.a.e.s.StatsdService    ] [node_sd4] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,821][INFO ][c.a.e.s.StatsdService    ] [node_sm0] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,822][INFO ][c.a.e.s.StatsdService    ] [node_sd3] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,822][INFO ][o.e.t.TransportService   ] [integ_5] publish_address {127.0.0.1:33953}, bound_addresses {[::1]:37665}, {127.0.0.1:33953}
[2019-06-21T11:37:44,822][INFO ][c.a.e.s.StatsdService    ] [node_sd5] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,821][INFO ][c.a.e.s.StatsdService    ] [node_sm2] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,823][INFO ][o.e.t.TransportService   ] [integ_2] publish_address {127.0.0.1:42515}, bound_addresses {[::1]:39845}, {127.0.0.1:42515}
[2019-06-21T11:37:44,830][INFO ][c.a.e.s.StatsdService    ] [node_sm1] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,832][INFO ][c.a.e.s.StatsdService    ] [node_sm0] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,834][INFO ][c.a.e.s.StatsdService    ] [node_sd4] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,835][INFO ][c.a.e.s.StatsdService    ] [node_sd3] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,839][INFO ][c.a.e.s.StatsdService    ] [node_sm2] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,839][INFO ][c.a.e.s.StatsdService    ] [node_sd5] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,843][INFO ][c.a.e.s.StatsdService    ] [node_sm0] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,845][INFO ][c.a.e.s.StatsdService    ] [node_sd4] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,846][INFO ][c.a.e.s.StatsdService    ] [node_sd3] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,848][INFO ][c.a.e.s.StatsdService    ] [node_sm1] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,850][INFO ][c.a.e.s.StatsdService    ] [node_sd5] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,851][INFO ][c.a.e.s.StatsdService    ] [node_sm2] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,855][INFO ][c.a.e.s.StatsdService    ] [node_sd4] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,857][INFO ][c.a.e.s.StatsdService    ] [node_sd3] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,858][INFO ][c.a.e.s.StatsdService    ] [node_sm0] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,860][INFO ][c.a.e.s.StatsdService    ] [node_sm1] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,862][INFO ][c.a.e.s.StatsdService    ] [node_sm2] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,863][INFO ][c.a.e.s.StatsdService    ] [node_sd5] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,866][INFO ][c.a.e.s.StatsdService    ] [node_sd4] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,868][INFO ][c.a.e.s.StatsdService    ] [node_sd3] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,869][INFO ][c.a.e.s.StatsdService    ] [node_sm0] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,870][INFO ][c.a.e.s.StatsdService    ] [node_sm1] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,873][INFO ][c.a.e.s.StatsdService    ] [node_sm2] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,873][INFO ][c.a.e.s.StatsdService    ] [node_sd5] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,877][INFO ][c.a.e.s.StatsdService    ] [node_sd4] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,878][INFO ][c.a.e.s.StatsdService    ] [node_sd3] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,880][INFO ][c.a.e.s.StatsdService    ] [node_sm0] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,881][INFO ][c.a.e.s.StatsdService    ] [node_sm1] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,884][INFO ][c.a.e.s.StatsdService    ] [node_sd5] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,886][INFO ][c.a.e.s.StatsdService    ] [node_sm2] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,887][INFO ][c.a.e.s.StatsdService    ] [node_sd4] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,892][INFO ][c.a.e.s.StatsdService    ] [node_sm0] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,893][INFO ][c.a.e.s.StatsdService    ] [node_sd3] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,893][INFO ][c.a.e.s.StatsdService    ] [node_sm1] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,897][INFO ][c.a.e.s.StatsdService    ] [node_sm2] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,898][INFO ][c.a.e.s.StatsdService    ] [node_sd4] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,903][INFO ][c.a.e.s.StatsdService    ] [node_sd3] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,905][INFO ][c.a.e.s.StatsdService    ] [node_sm0] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,907][INFO ][c.a.e.s.StatsdService    ] [node_sd5] Cluster state not set yet. Looping...
[2019-06-21T11:37:44,953][INFO ][o.e.t.d.MockZenPing      ] [node_sm0] pinging using mock zen ping
[2019-06-21T11:37:45,038][INFO ][o.e.t.d.MockZenPing      ] [node_sm1] pinging using mock zen ping
[2019-06-21T11:37:45,046][INFO ][o.e.t.d.MockZenPing      ] [node_sd3] pinging using mock zen ping
[2019-06-21T11:37:45,050][INFO ][o.e.t.d.MockZenPing      ] [node_sd4] pinging using mock zen ping
[2019-06-21T11:37:45,053][INFO ][o.e.t.d.MockZenPing      ] [node_sm2] pinging using mock zen ping
[2019-06-21T11:37:45,053][INFO ][o.e.t.d.MockZenPing      ] [node_sd5] pinging using mock zen ping
[2019-06-21T11:37:45,386][INFO ][o.e.c.s.MasterService    ] [node_sm0] zen-disco-elected-as-master ([2] nodes joined)[{node_sd4}{nolVJCRtRIywePi6dR04_A}{cvP8V-UuTi65m7eVFbtyqA}{127.0.0.1}{127.0.0.1:33953}, {node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515}], zen-disco-node-join[{node_sm2}{iQGbf2jpRUqidirSGmOd0Q}{aqb88EsXStusCdqRySzfNQ}{127.0.0.1}{127.0.0.1:34709}, {node_sd5}{BKRP-ZBsQTyr8oAE7yCU5A}{B5kP-kV-QRKOCAW4kfgSLQ}{127.0.0.1}{127.0.0.1:33651}, {node_sd3}{dfQYD9HKRnCVFJcY0yiusA}{NuofZW0lQHqu0ug8-pLy7g}{127.0.0.1}{127.0.0.1:42637}], reason: new_master {node_sm0}{9mLcvpOrSYOY8tzGqd4M1g}{aIUM7TCVRRWeApUecsLPuw}{127.0.0.1}{127.0.0.1:39595}, added {{node_sd4}{nolVJCRtRIywePi6dR04_A}{cvP8V-UuTi65m7eVFbtyqA}{127.0.0.1}{127.0.0.1:33953},{node_sd5}{BKRP-ZBsQTyr8oAE7yCU5A}{B5kP-kV-QRKOCAW4kfgSLQ}{127.0.0.1}{127.0.0.1:33651},{node_sm2}{iQGbf2jpRUqidirSGmOd0Q}{aqb88EsXStusCdqRySzfNQ}{127.0.0.1}{127.0.0.1:34709},{node_sd3}{dfQYD9HKRnCVFJcY0yiusA}{NuofZW0lQHqu0ug8-pLy7g}{127.0.0.1}{127.0.0.1:42637},{node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515},}
[2019-06-21T11:37:45,449][INFO ][o.e.c.s.ClusterApplierService] [node_sm1] detected_master {node_sm0}{9mLcvpOrSYOY8tzGqd4M1g}{aIUM7TCVRRWeApUecsLPuw}{127.0.0.1}{127.0.0.1:39595}, added {{node_sd4}{nolVJCRtRIywePi6dR04_A}{cvP8V-UuTi65m7eVFbtyqA}{127.0.0.1}{127.0.0.1:33953},{node_sm0}{9mLcvpOrSYOY8tzGqd4M1g}{aIUM7TCVRRWeApUecsLPuw}{127.0.0.1}{127.0.0.1:39595},{node_sm2}{iQGbf2jpRUqidirSGmOd0Q}{aqb88EsXStusCdqRySzfNQ}{127.0.0.1}{127.0.0.1:34709},{node_sd3}{dfQYD9HKRnCVFJcY0yiusA}{NuofZW0lQHqu0ug8-pLy7g}{127.0.0.1}{127.0.0.1:42637},{node_sd5}{BKRP-ZBsQTyr8oAE7yCU5A}{B5kP-kV-QRKOCAW4kfgSLQ}{127.0.0.1}{127.0.0.1:33651},}, reason: apply cluster state (from master [master {node_sm0}{9mLcvpOrSYOY8tzGqd4M1g}{aIUM7TCVRRWeApUecsLPuw}{127.0.0.1}{127.0.0.1:39595} committed version [1]])
[2019-06-21T11:37:45,455][INFO ][o.e.c.s.ClusterApplierService] [node_sd5] detected_master {node_sm0}{9mLcvpOrSYOY8tzGqd4M1g}{aIUM7TCVRRWeApUecsLPuw}{127.0.0.1}{127.0.0.1:39595}, added {{node_sd4}{nolVJCRtRIywePi6dR04_A}{cvP8V-UuTi65m7eVFbtyqA}{127.0.0.1}{127.0.0.1:33953},{node_sm0}{9mLcvpOrSYOY8tzGqd4M1g}{aIUM7TCVRRWeApUecsLPuw}{127.0.0.1}{127.0.0.1:39595},{node_sm2}{iQGbf2jpRUqidirSGmOd0Q}{aqb88EsXStusCdqRySzfNQ}{127.0.0.1}{127.0.0.1:34709},{node_sd3}{dfQYD9HKRnCVFJcY0yiusA}{NuofZW0lQHqu0ug8-pLy7g}{127.0.0.1}{127.0.0.1:42637},{node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515},}, reason: apply cluster state (from master [master {node_sm0}{9mLcvpOrSYOY8tzGqd4M1g}{aIUM7TCVRRWeApUecsLPuw}{127.0.0.1}{127.0.0.1:39595} committed version [1]])
[2019-06-21T11:37:45,451][INFO ][o.e.c.s.ClusterApplierService] [node_sm2] detected_master {node_sm0}{9mLcvpOrSYOY8tzGqd4M1g}{aIUM7TCVRRWeApUecsLPuw}{127.0.0.1}{127.0.0.1:39595}, added {{node_sd4}{nolVJCRtRIywePi6dR04_A}{cvP8V-UuTi65m7eVFbtyqA}{127.0.0.1}{127.0.0.1:33953},{node_sm0}{9mLcvpOrSYOY8tzGqd4M1g}{aIUM7TCVRRWeApUecsLPuw}{127.0.0.1}{127.0.0.1:39595},{node_sd3}{dfQYD9HKRnCVFJcY0yiusA}{NuofZW0lQHqu0ug8-pLy7g}{127.0.0.1}{127.0.0.1:42637},{node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515},{node_sd5}{BKRP-ZBsQTyr8oAE7yCU5A}{B5kP-kV-QRKOCAW4kfgSLQ}{127.0.0.1}{127.0.0.1:33651},}, reason: apply cluster state (from master [master {node_sm0}{9mLcvpOrSYOY8tzGqd4M1g}{aIUM7TCVRRWeApUecsLPuw}{127.0.0.1}{127.0.0.1:39595} committed version [1]])
[2019-06-21T11:37:45,451][INFO ][o.e.c.s.ClusterApplierService] [node_sd4] detected_master {node_sm0}{9mLcvpOrSYOY8tzGqd4M1g}{aIUM7TCVRRWeApUecsLPuw}{127.0.0.1}{127.0.0.1:39595}, added {{node_sm0}{9mLcvpOrSYOY8tzGqd4M1g}{aIUM7TCVRRWeApUecsLPuw}{127.0.0.1}{127.0.0.1:39595},{node_sm2}{iQGbf2jpRUqidirSGmOd0Q}{aqb88EsXStusCdqRySzfNQ}{127.0.0.1}{127.0.0.1:34709},{node_sd3}{dfQYD9HKRnCVFJcY0yiusA}{NuofZW0lQHqu0ug8-pLy7g}{127.0.0.1}{127.0.0.1:42637},{node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515},{node_sd5}{BKRP-ZBsQTyr8oAE7yCU5A}{B5kP-kV-QRKOCAW4kfgSLQ}{127.0.0.1}{127.0.0.1:33651},}, reason: apply cluster state (from master [master {node_sm0}{9mLcvpOrSYOY8tzGqd4M1g}{aIUM7TCVRRWeApUecsLPuw}{127.0.0.1}{127.0.0.1:39595} committed version [1]])
[2019-06-21T11:37:45,450][INFO ][o.e.c.s.ClusterApplierService] [node_sd3] detected_master {node_sm0}{9mLcvpOrSYOY8tzGqd4M1g}{aIUM7TCVRRWeApUecsLPuw}{127.0.0.1}{127.0.0.1:39595}, added {{node_sd4}{nolVJCRtRIywePi6dR04_A}{cvP8V-UuTi65m7eVFbtyqA}{127.0.0.1}{127.0.0.1:33953},{node_sm0}{9mLcvpOrSYOY8tzGqd4M1g}{aIUM7TCVRRWeApUecsLPuw}{127.0.0.1}{127.0.0.1:39595},{node_sm2}{iQGbf2jpRUqidirSGmOd0Q}{aqb88EsXStusCdqRySzfNQ}{127.0.0.1}{127.0.0.1:34709},{node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515},{node_sd5}{BKRP-ZBsQTyr8oAE7yCU5A}{B5kP-kV-QRKOCAW4kfgSLQ}{127.0.0.1}{127.0.0.1:33651},}, reason: apply cluster state (from master [master {node_sm0}{9mLcvpOrSYOY8tzGqd4M1g}{aIUM7TCVRRWeApUecsLPuw}{127.0.0.1}{127.0.0.1:39595} committed version [1]])
[2019-06-21T11:37:45,695][INFO ][o.e.n.Node               ] [integ_3] started
[2019-06-21T11:37:45,702][INFO ][o.e.n.Node               ] [integ_6] started
[2019-06-21T11:37:45,715][INFO ][o.e.n.Node               ] [integ_5] started
[2019-06-21T11:37:45,731][INFO ][o.e.n.Node               ] [integ_4] started
[2019-06-21T11:37:45,731][INFO ][o.e.n.Node               ] [integ_2] started
[2019-06-21T11:37:45,736][INFO ][o.e.c.s.ClusterApplierService] [node_sm0] new_master {node_sm0}{9mLcvpOrSYOY8tzGqd4M1g}{aIUM7TCVRRWeApUecsLPuw}{127.0.0.1}{127.0.0.1:39595}, added {{node_sd4}{nolVJCRtRIywePi6dR04_A}{cvP8V-UuTi65m7eVFbtyqA}{127.0.0.1}{127.0.0.1:33953},{node_sd5}{BKRP-ZBsQTyr8oAE7yCU5A}{B5kP-kV-QRKOCAW4kfgSLQ}{127.0.0.1}{127.0.0.1:33651},{node_sm2}{iQGbf2jpRUqidirSGmOd0Q}{aqb88EsXStusCdqRySzfNQ}{127.0.0.1}{127.0.0.1:34709},{node_sd3}{dfQYD9HKRnCVFJcY0yiusA}{NuofZW0lQHqu0ug8-pLy7g}{127.0.0.1}{127.0.0.1:42637},{node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515},}, reason: apply cluster state (from master [master {node_sm0}{9mLcvpOrSYOY8tzGqd4M1g}{aIUM7TCVRRWeApUecsLPuw}{127.0.0.1}{127.0.0.1:39595} committed version [1] source [zen-disco-elected-as-master ([2] nodes joined)[{node_sd4}{nolVJCRtRIywePi6dR04_A}{cvP8V-UuTi65m7eVFbtyqA}{127.0.0.1}{127.0.0.1:33953}, {node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515}], zen-disco-node-join[{node_sm2}{iQGbf2jpRUqidirSGmOd0Q}{aqb88EsXStusCdqRySzfNQ}{127.0.0.1}{127.0.0.1:34709}, {node_sd5}{BKRP-ZBsQTyr8oAE7yCU5A}{B5kP-kV-QRKOCAW4kfgSLQ}{127.0.0.1}{127.0.0.1:33651}, {node_sd3}{dfQYD9HKRnCVFJcY0yiusA}{NuofZW0lQHqu0ug8-pLy7g}{127.0.0.1}{127.0.0.1:42637}]]])
[2019-06-21T11:37:45,775][INFO ][o.e.n.Node               ] [integ_1] started
[2019-06-21T11:37:45,796][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] no modules loaded
[2019-06-21T11:37:45,796][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.transport.MockTcpTransportPlugin]
[2019-06-21T11:37:45,947][ERROR][c.a.e.s.StatsdService    ] [node_sm0] Unable to send cluster wide stats
org.elasticsearch.cluster.block.ClusterBlockException: blocked by: [SERVICE_UNAVAILABLE/1/state not recovered / initialized];
        at org.elasticsearch.cluster.block.ClusterBlocks.globalBlockedException(ClusterBlocks.java:191) ~[elasticsearch-6.8.0.jar:6.8.0]
        at org.elasticsearch.action.admin.indices.stats.TransportIndicesStatsAction.checkGlobalBlock(TransportIndicesStatsAction.java:72) ~[elasticsearch-6.8.0.jar:6.8.0]
        at org.elasticsearch.action.admin.indices.stats.TransportIndicesStatsAction.checkGlobalBlock(TransportIndicesStatsAction.java:49) ~[elasticsearch-6.8.0.jar:6.8.0]
        at org.elasticsearch.action.support.broadcast.node.TransportBroadcastByNodeAction$AsyncAction.<init>(TransportBroadcastByNodeAction.java:258) ~[elasticsearch-6.8.0.jar:6.8.0]
        at org.elasticsearch.action.support.broadcast.node.TransportBroadcastByNodeAction.doExecute(TransportBroadcastByNodeAction.java:236) ~[elasticsearch-6.8.0.jar:6.8.0]
        at org.elasticsearch.action.support.broadcast.node.TransportBroadcastByNodeAction.doExecute(TransportBroadcastByNodeAction.java:78) ~[elasticsearch-6.8.0.jar:6.8.0]
        at org.elasticsearch.action.support.TransportAction$RequestFilterChain.proceed(TransportAction.java:167) ~[elasticsearch-6.8.0.jar:6.8.0]
        at org.elasticsearch.action.support.TransportAction.execute(TransportAction.java:139) ~[elasticsearch-6.8.0.jar:6.8.0]
        at org.elasticsearch.action.support.TransportAction.execute(TransportAction.java:81) ~[elasticsearch-6.8.0.jar:6.8.0]
        at org.elasticsearch.client.node.NodeClient.executeLocally(NodeClient.java:87) ~[elasticsearch-6.8.0.jar:6.8.0]
        at org.elasticsearch.client.node.NodeClient.doExecute(NodeClient.java:76) ~[elasticsearch-6.8.0.jar:6.8.0]
        at org.elasticsearch.client.support.AbstractClient.execute(AbstractClient.java:403) ~[elasticsearch-6.8.0.jar:6.8.0]
        at org.elasticsearch.client.support.AbstractClient.execute(AbstractClient.java:391) ~[elasticsearch-6.8.0.jar:6.8.0]
        at org.elasticsearch.client.support.AbstractClient$IndicesAdmin.execute(AbstractClient.java:1262) ~[elasticsearch-6.8.0.jar:6.8.0]
        at org.elasticsearch.action.ActionRequestBuilder.execute(ActionRequestBuilder.java:46) ~[elasticsearch-6.8.0.jar:6.8.0]
        at org.elasticsearch.action.ActionRequestBuilder.get(ActionRequestBuilder.java:53) ~[elasticsearch-6.8.0.jar:6.8.0]
        at com.automattic.elasticsearch.statsd.StatsdService$StatsdReporterThread.run(StatsdService.java:196) [classes/:?]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_212]
[2019-06-21T11:37:45,998][INFO ][o.e.g.GatewayService     ] [node_sm0] recovered [0] indices into cluster_state
[2019-06-21T11:37:46,152][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] no modules loaded
[2019-06-21T11:37:46,153][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.transport.MockTcpTransportPlugin]
[2019-06-21T11:37:46,516][INFO ][o.e.c.m.MetaDataIndexTemplateService] [node_sm0] adding template [random_index_template] for index patterns [*]
[2019-06-21T11:37:46,571][INFO ][c.a.e.s.t.StatsdPluginIntegrationTest] [testThatIndexingResultsInMonitoring] [StatsdPluginIntegrationTest#testThatIndexingResultsInMonitoring]: all set up test
[2019-06-21T11:37:46,572][INFO ][c.a.e.s.t.StatsdPluginIntegrationTest] [testThatIndexingResultsInMonitoring] Creating index 691ae5
[2019-06-21T11:37:46,573][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] no modules loaded
[2019-06-21T11:37:46,573][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.transport.MockTcpTransportPlugin]
[2019-06-21T11:37:46,683][INFO ][o.e.c.m.MetaDataCreateIndexService] [node_sm0] [691ae5] creating index, cause [api], templates [random_index_template], shards [4]/[1], mappings []
[2019-06-21T11:37:48,945][INFO ][o.e.c.r.a.AllocationService] [node_sm0] Cluster health status changed from [YELLOW] to [GREEN] (reason: [shards started [[691ae5][0], [691ae5][2], [691ae5][1]] ...]).
[2019-06-21T11:37:49,131][INFO ][o.e.c.m.MetaDataMappingService] [node_sm0] [691ae5/h4tVc2B6Q-i459425Y6_Gg] create_mapping [af0d44]
[2019-06-21T11:37:50,063][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] no modules loaded
[2019-06-21T11:37:50,063][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.transport.MockTcpTransportPlugin]
[2019-06-21T11:37:50,524][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] no modules loaded
[2019-06-21T11:37:50,524][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.transport.MockTcpTransportPlugin]
[2019-06-21T11:37:50,788][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] no modules loaded
[2019-06-21T11:37:50,789][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.transport.MockTcpTransportPlugin]
[2019-06-21T11:37:54,361][INFO ][c.a.e.s.t.StatsdPluginIntegrationTest] [testThatIndexingResultsInMonitoring] [StatsdPluginIntegrationTest#testThatIndexingResultsInMonitoring]: cleaning up after test
[2019-06-21T11:37:54,576][INFO ][o.e.c.m.MetaDataDeleteIndexService] [node_sm0] [691ae5/h4tVc2B6Q-i459425Y6_Gg] deleting index
[2019-06-21T11:37:54,609][INFO ][o.e.t.s.MockFSIndexStore$Listener] [node_sd4] [691ae5][1] start check index
[2019-06-21T11:37:54,641][INFO ][o.e.t.s.MockFSIndexStore$Listener] [node_sd5] [691ae5][0] start check index
[2019-06-21T11:37:54,659][INFO ][o.e.t.s.MockFSIndexStore$Listener] [node_sd3] [691ae5][0] start check index
[2019-06-21T11:37:54,768][INFO ][o.e.t.s.MockFSIndexStore$Listener] [node_sd3] [691ae5][0] end check index
[2019-06-21T11:37:54,804][INFO ][o.e.t.s.MockFSIndexStore$Listener] [node_sd4] [691ae5][1] end check index
[2019-06-21T11:37:54,815][INFO ][o.e.t.s.MockFSIndexStore$Listener] [node_sd5] [691ae5][0] end check index
[2019-06-21T11:37:54,818][INFO ][o.e.t.s.MockFSIndexStore$Listener] [node_sd3] [691ae5][1] start check index
[2019-06-21T11:37:54,866][INFO ][o.e.t.s.MockFSIndexStore$Listener] [node_sd4] [691ae5][2] start check index
[2019-06-21T11:37:54,871][INFO ][o.e.t.s.MockFSIndexStore$Listener] [node_sd5] [691ae5][3] start check index
[2019-06-21T11:37:54,883][INFO ][o.e.t.s.MockFSIndexStore$Listener] [node_sd3] [691ae5][1] end check index
[2019-06-21T11:37:54,922][INFO ][o.e.t.s.MockFSIndexStore$Listener] [node_sd3] [691ae5][2] start check index
[2019-06-21T11:37:54,944][INFO ][o.e.t.s.MockFSIndexStore$Listener] [node_sd4] [691ae5][2] end check index
[2019-06-21T11:37:55,010][INFO ][o.e.t.s.MockFSIndexStore$Listener] [node_sd3] [691ae5][2] end check index
[2019-06-21T11:37:55,011][INFO ][o.e.t.s.MockFSIndexStore$Listener] [node_sd5] [691ae5][3] end check index
[2019-06-21T11:37:55,074][INFO ][o.e.t.s.MockFSIndexStore$Listener] [node_sd4] [691ae5][3] start check index
[2019-06-21T11:37:55,113][INFO ][o.e.t.s.MockFSIndexStore$Listener] [node_sd4] [691ae5][3] end check index
[2019-06-21T11:37:55,172][INFO ][o.e.c.m.MetaDataIndexTemplateService] [node_sm0] removing template [random_index_template]
[2019-06-21T11:37:55,225][INFO ][c.a.e.s.t.StatsdPluginIntegrationTest] [testThatIndexingResultsInMonitoring] [StatsdPluginIntegrationTest#testThatIndexingResultsInMonitoring]: cleaned up after test
[2019-06-21T11:37:55,233][INFO ][c.a.e.s.t.StatsdPluginIntegrationTest] [testThatIndexingResultsInMonitoring] after test
[2019-06-21T11:37:55,550][INFO ][c.a.e.s.t.StatsdPluginIntegrationTest] [masterFailOverShouldWork] before test
[2019-06-21T11:37:55,550][INFO ][c.a.e.s.t.StatsdPluginIntegrationTest] [masterFailOverShouldWork] [StatsdPluginIntegrationTest#masterFailOverShouldWork]: setting up test
[2019-06-21T11:37:55,653][INFO ][o.e.c.m.MetaDataIndexTemplateService] [node_sm0] adding template [random_index_template] for index patterns [*]
[2019-06-21T11:37:55,684][INFO ][c.a.e.s.t.StatsdPluginIntegrationTest] [masterFailOverShouldWork] [StatsdPluginIntegrationTest#masterFailOverShouldWork]: all set up test
[2019-06-21T11:37:55,685][INFO ][c.a.e.s.t.StatsdPluginIntegrationTest] [masterFailOverShouldWork] Creating index cf2440
[2019-06-21T11:37:55,695][INFO ][o.e.c.m.MetaDataCreateIndexService] [node_sm0] [cf2440] creating index, cause [api], templates [random_index_template], shards [4]/[1], mappings []
[2019-06-21T11:37:56,201][INFO ][o.e.c.m.MetaDataMappingService] [node_sm0] [cf2440/ww5ckwP8T8mbeQYIVCQOXw] create_mapping [af0d44]
[2019-06-21T11:37:56,686][INFO ][o.e.t.InternalTestCluster] [masterFailOverShouldWork] Closing master node [node_sm0] 
[2019-06-21T11:37:56,688][INFO ][o.e.c.r.a.AllocationService] [node_sm0] Cluster health status changed from [YELLOW] to [GREEN] (reason: [shards started [[cf2440][2]] ...]).
[2019-06-21T11:37:56,737][INFO ][o.e.n.Node               ] [masterFailOverShouldWork] stopping ...
[2019-06-21T11:37:56,741][INFO ][o.e.d.z.ZenDiscovery     ] [node_sm1] master_left [{node_sm0}{9mLcvpOrSYOY8tzGqd4M1g}{aIUM7TCVRRWeApUecsLPuw}{127.0.0.1}{127.0.0.1:39595}], reason [shut_down]
[2019-06-21T11:37:56,746][WARN ][o.e.d.z.ZenDiscovery     ] [node_sm1] master left (reason = shut_down), current nodes: nodes: 
   {node_sd4}{nolVJCRtRIywePi6dR04_A}{cvP8V-UuTi65m7eVFbtyqA}{127.0.0.1}{127.0.0.1:33953}
   {node_sm0}{9mLcvpOrSYOY8tzGqd4M1g}{aIUM7TCVRRWeApUecsLPuw}{127.0.0.1}{127.0.0.1:39595}, master
   {node_sm2}{iQGbf2jpRUqidirSGmOd0Q}{aqb88EsXStusCdqRySzfNQ}{127.0.0.1}{127.0.0.1:34709}
   {node_sd3}{dfQYD9HKRnCVFJcY0yiusA}{NuofZW0lQHqu0ug8-pLy7g}{127.0.0.1}{127.0.0.1:42637}
   {node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515}, local
   {node_sd5}{BKRP-ZBsQTyr8oAE7yCU5A}{B5kP-kV-QRKOCAW4kfgSLQ}{127.0.0.1}{127.0.0.1:33651}

[2019-06-21T11:37:56,750][INFO ][o.e.d.z.ZenDiscovery     ] [node_sm2] master_left [{node_sm0}{9mLcvpOrSYOY8tzGqd4M1g}{aIUM7TCVRRWeApUecsLPuw}{127.0.0.1}{127.0.0.1:39595}], reason [shut_down]
[2019-06-21T11:37:56,751][WARN ][o.e.d.z.ZenDiscovery     ] [node_sm2] master left (reason = shut_down), current nodes: nodes: 
   {node_sd4}{nolVJCRtRIywePi6dR04_A}{cvP8V-UuTi65m7eVFbtyqA}{127.0.0.1}{127.0.0.1:33953}
   {node_sm0}{9mLcvpOrSYOY8tzGqd4M1g}{aIUM7TCVRRWeApUecsLPuw}{127.0.0.1}{127.0.0.1:39595}, master
   {node_sm2}{iQGbf2jpRUqidirSGmOd0Q}{aqb88EsXStusCdqRySzfNQ}{127.0.0.1}{127.0.0.1:34709}, local
   {node_sd3}{dfQYD9HKRnCVFJcY0yiusA}{NuofZW0lQHqu0ug8-pLy7g}{127.0.0.1}{127.0.0.1:42637}
   {node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515}
   {node_sd5}{BKRP-ZBsQTyr8oAE7yCU5A}{B5kP-kV-QRKOCAW4kfgSLQ}{127.0.0.1}{127.0.0.1:33651}

[2019-06-21T11:37:56,754][INFO ][o.e.t.d.MockZenPing      ] [node_sm1] pinging using mock zen ping
[2019-06-21T11:37:56,756][INFO ][o.e.t.d.MockZenPing      ] [node_sm2] pinging using mock zen ping
[2019-06-21T11:37:56,775][INFO ][o.e.d.z.ZenDiscovery     ] [node_sd3] master_left [{node_sm0}{9mLcvpOrSYOY8tzGqd4M1g}{aIUM7TCVRRWeApUecsLPuw}{127.0.0.1}{127.0.0.1:39595}], reason [transport disconnected]
[2019-06-21T11:37:56,776][WARN ][o.e.d.z.ZenDiscovery     ] [node_sd3] master left (reason = transport disconnected), current nodes: nodes: 
   {node_sd4}{nolVJCRtRIywePi6dR04_A}{cvP8V-UuTi65m7eVFbtyqA}{127.0.0.1}{127.0.0.1:33953}
   {node_sm0}{9mLcvpOrSYOY8tzGqd4M1g}{aIUM7TCVRRWeApUecsLPuw}{127.0.0.1}{127.0.0.1:39595}, master
   {node_sm2}{iQGbf2jpRUqidirSGmOd0Q}{aqb88EsXStusCdqRySzfNQ}{127.0.0.1}{127.0.0.1:34709}
   {node_sd3}{dfQYD9HKRnCVFJcY0yiusA}{NuofZW0lQHqu0ug8-pLy7g}{127.0.0.1}{127.0.0.1:42637}, local
   {node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515}
   {node_sd5}{BKRP-ZBsQTyr8oAE7yCU5A}{B5kP-kV-QRKOCAW4kfgSLQ}{127.0.0.1}{127.0.0.1:33651}

[2019-06-21T11:37:56,779][INFO ][o.e.d.z.ZenDiscovery     ] [node_sd4] master_left [{node_sm0}{9mLcvpOrSYOY8tzGqd4M1g}{aIUM7TCVRRWeApUecsLPuw}{127.0.0.1}{127.0.0.1:39595}], reason [transport disconnected]
[2019-06-21T11:37:56,780][WARN ][o.e.d.z.ZenDiscovery     ] [node_sd4] master left (reason = transport disconnected), current nodes: nodes: 
   {node_sd4}{nolVJCRtRIywePi6dR04_A}{cvP8V-UuTi65m7eVFbtyqA}{127.0.0.1}{127.0.0.1:33953}, local
   {node_sm0}{9mLcvpOrSYOY8tzGqd4M1g}{aIUM7TCVRRWeApUecsLPuw}{127.0.0.1}{127.0.0.1:39595}, master
   {node_sm2}{iQGbf2jpRUqidirSGmOd0Q}{aqb88EsXStusCdqRySzfNQ}{127.0.0.1}{127.0.0.1:34709}
   {node_sd3}{dfQYD9HKRnCVFJcY0yiusA}{NuofZW0lQHqu0ug8-pLy7g}{127.0.0.1}{127.0.0.1:42637}
   {node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515}
   {node_sd5}{BKRP-ZBsQTyr8oAE7yCU5A}{B5kP-kV-QRKOCAW4kfgSLQ}{127.0.0.1}{127.0.0.1:33651}

[2019-06-21T11:37:56,782][ERROR][c.a.e.s.StatsdService    ] [node_sm0] Exiting StatsdReporterThread
[2019-06-21T11:37:56,782][INFO ][o.e.d.z.ZenDiscovery     ] [node_sd5] master_left [{node_sm0}{9mLcvpOrSYOY8tzGqd4M1g}{aIUM7TCVRRWeApUecsLPuw}{127.0.0.1}{127.0.0.1:39595}], reason [transport disconnected]
[2019-06-21T11:37:56,782][WARN ][o.e.d.z.ZenDiscovery     ] [node_sd5] master left (reason = transport disconnected), current nodes: nodes: 
   {node_sd4}{nolVJCRtRIywePi6dR04_A}{cvP8V-UuTi65m7eVFbtyqA}{127.0.0.1}{127.0.0.1:33953}
   {node_sm0}{9mLcvpOrSYOY8tzGqd4M1g}{aIUM7TCVRRWeApUecsLPuw}{127.0.0.1}{127.0.0.1:39595}, master
   {node_sm2}{iQGbf2jpRUqidirSGmOd0Q}{aqb88EsXStusCdqRySzfNQ}{127.0.0.1}{127.0.0.1:34709}
   {node_sd3}{dfQYD9HKRnCVFJcY0yiusA}{NuofZW0lQHqu0ug8-pLy7g}{127.0.0.1}{127.0.0.1:42637}
   {node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515}
   {node_sd5}{BKRP-ZBsQTyr8oAE7yCU5A}{B5kP-kV-QRKOCAW4kfgSLQ}{127.0.0.1}{127.0.0.1:33651}, local

[2019-06-21T11:37:56,782][INFO ][c.a.e.s.StatsdService    ] [masterFailOverShouldWork] StatsD reporter stopped
[2019-06-21T11:37:56,785][INFO ][o.e.n.Node               ] [masterFailOverShouldWork] stopped
[2019-06-21T11:37:56,787][INFO ][o.e.n.Node               ] [masterFailOverShouldWork] closing ...
[2019-06-21T11:37:56,808][INFO ][o.e.t.d.MockZenPing      ] [node_sd5] pinging using mock zen ping
[2019-06-21T11:37:56,808][INFO ][o.e.t.d.MockZenPing      ] [node_sd3] pinging using mock zen ping
[2019-06-21T11:37:56,809][INFO ][o.e.t.d.MockZenPing      ] [node_sd4] pinging using mock zen ping
[2019-06-21T11:37:56,845][WARN ][o.e.c.NodeConnectionsService] [node_sd5] failed to connect to node {node_sm0}{9mLcvpOrSYOY8tzGqd4M1g}{aIUM7TCVRRWeApUecsLPuw}{127.0.0.1}{127.0.0.1:39595} (tried [1] times)
org.elasticsearch.transport.ConnectTransportException: [node_sm0][127.0.0.1:39595] connect_exception
        at org.elasticsearch.transport.TcpTransport$ChannelsConnectedListener.onFailure(TcpTransport.java:1309) ~[elasticsearch-6.8.0.jar:6.8.0]
        at org.elasticsearch.action.ActionListener.lambda$toBiConsumer$2(ActionListener.java:100) ~[elasticsearch-6.8.0.jar:6.8.0]
        at org.elasticsearch.common.concurrent.CompletableContext.lambda$addListener$0(CompletableContext.java:42) ~[elasticsearch-core-6.8.0.jar:6.8.0]
        at java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:760) ~[?:1.8.0_212]
        at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:736) ~[?:1.8.0_212]
        at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:474) ~[?:1.8.0_212]
        at java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:1977) ~[?:1.8.0_212]
        at org.elasticsearch.common.concurrent.CompletableContext.completeExceptionally(CompletableContext.java:57) ~[elasticsearch-core-6.8.0.jar:6.8.0]
        at org.elasticsearch.transport.MockTcpTransport.lambda$initiateChannel$0(MockTcpTransport.java:195) ~[framework-6.8.0.jar:6.8.0]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) ~[?:1.8.0_212]
        at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~[?:1.8.0_212]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_212]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_212]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_212]
Caused by: java.net.ConnectException: Connection refused (Connection refused)
        at java.net.PlainSocketImpl.socketConnect(Native Method) ~[?:1.8.0_212]
        at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:350) ~[?:1.8.0_212]
        at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:206) ~[?:1.8.0_212]
        at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:188) ~[?:1.8.0_212]
        at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392) ~[?:1.8.0_212]
        at java.net.Socket.connect(Socket.java:589) ~[?:1.8.0_212]
        at org.elasticsearch.mocksocket.MockSocket.access$101(MockSocket.java:32) ~[mocksocket-1.2.jar:?]
        at org.elasticsearch.mocksocket.MockSocket.lambda$connect$0(MockSocket.java:66) ~[mocksocket-1.2.jar:?]
        at java.security.AccessController.doPrivileged(Native Method) ~[?:1.8.0_212]
        at org.elasticsearch.mocksocket.MockSocket.connect(MockSocket.java:65) ~[mocksocket-1.2.jar:?]
        at org.elasticsearch.mocksocket.MockSocket.connect(MockSocket.java:59) ~[mocksocket-1.2.jar:?]
        at org.elasticsearch.transport.MockTcpTransport.lambda$initiateChannel$0(MockTcpTransport.java:190) ~[framework-6.8.0.jar:6.8.0]
        ... 5 more
[2019-06-21T11:37:56,863][INFO ][o.e.n.Node               ] [masterFailOverShouldWork] closed
[2019-06-21T11:37:56,845][WARN ][o.e.c.NodeConnectionsService] [node_sd3] failed to connect to node {node_sm0}{9mLcvpOrSYOY8tzGqd4M1g}{aIUM7TCVRRWeApUecsLPuw}{127.0.0.1}{127.0.0.1:39595} (tried [1] times)
org.elasticsearch.transport.ConnectTransportException: [node_sm0][127.0.0.1:39595] connect_exception
        at org.elasticsearch.transport.TcpTransport$ChannelsConnectedListener.onFailure(TcpTransport.java:1309) ~[elasticsearch-6.8.0.jar:6.8.0]
        at org.elasticsearch.action.ActionListener.lambda$toBiConsumer$2(ActionListener.java:100) ~[elasticsearch-6.8.0.jar:6.8.0]
        at org.elasticsearch.common.concurrent.CompletableContext.lambda$addListener$0(CompletableContext.java:42) ~[elasticsearch-core-6.8.0.jar:6.8.0]
        at java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:760) ~[?:1.8.0_212]
        at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:736) ~[?:1.8.0_212]
        at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:474) ~[?:1.8.0_212]
        at java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:1977) ~[?:1.8.0_212]
        at org.elasticsearch.common.concurrent.CompletableContext.completeExceptionally(CompletableContext.java:57) ~[elasticsearch-core-6.8.0.jar:6.8.0]
        at org.elasticsearch.transport.MockTcpTransport.lambda$initiateChannel$0(MockTcpTransport.java:195) ~[framework-6.8.0.jar:6.8.0]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) ~[?:1.8.0_212]
        at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~[?:1.8.0_212]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_212]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_212]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_212]
Caused by: java.net.ConnectException: Connection refused (Connection refused)
        at java.net.PlainSocketImpl.socketConnect(Native Method) ~[?:1.8.0_212]
        at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:350) ~[?:1.8.0_212]
        at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:206) ~[?:1.8.0_212]
        at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:188) ~[?:1.8.0_212]
        at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392) ~[?:1.8.0_212]
        at java.net.Socket.connect(Socket.java:589) ~[?:1.8.0_212]
        at org.elasticsearch.mocksocket.MockSocket.access$101(MockSocket.java:32) ~[mocksocket-1.2.jar:?]
        at org.elasticsearch.mocksocket.MockSocket.lambda$connect$0(MockSocket.java:66) ~[mocksocket-1.2.jar:?]
        at java.security.AccessController.doPrivileged(Native Method) ~[?:1.8.0_212]
        at org.elasticsearch.mocksocket.MockSocket.connect(MockSocket.java:65) ~[mocksocket-1.2.jar:?]
        at org.elasticsearch.mocksocket.MockSocket.connect(MockSocket.java:59) ~[mocksocket-1.2.jar:?]
        at org.elasticsearch.transport.MockTcpTransport.lambda$initiateChannel$0(MockTcpTransport.java:190) ~[framework-6.8.0.jar:6.8.0]
        ... 5 more
[2019-06-21T11:37:56,846][WARN ][o.e.c.NodeConnectionsService] [node_sd4] failed to connect to node {node_sm0}{9mLcvpOrSYOY8tzGqd4M1g}{aIUM7TCVRRWeApUecsLPuw}{127.0.0.1}{127.0.0.1:39595} (tried [1] times)
org.elasticsearch.transport.ConnectTransportException: [node_sm0][127.0.0.1:39595] connect_exception
        at org.elasticsearch.transport.TcpTransport$ChannelsConnectedListener.onFailure(TcpTransport.java:1309) ~[elasticsearch-6.8.0.jar:6.8.0]
        at org.elasticsearch.action.ActionListener.lambda$toBiConsumer$2(ActionListener.java:100) ~[elasticsearch-6.8.0.jar:6.8.0]
        at org.elasticsearch.common.concurrent.CompletableContext.lambda$addListener$0(CompletableContext.java:42) ~[elasticsearch-core-6.8.0.jar:6.8.0]
        at java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:760) ~[?:1.8.0_212]
        at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:736) ~[?:1.8.0_212]
        at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:474) ~[?:1.8.0_212]
        at java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:1977) ~[?:1.8.0_212]
        at org.elasticsearch.common.concurrent.CompletableContext.completeExceptionally(CompletableContext.java:57) ~[elasticsearch-core-6.8.0.jar:6.8.0]
        at org.elasticsearch.transport.MockTcpTransport.lambda$initiateChannel$0(MockTcpTransport.java:195) ~[framework-6.8.0.jar:6.8.0]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) ~[?:1.8.0_212]
        at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~[?:1.8.0_212]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_212]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_212]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_212]
Caused by: java.net.ConnectException: Connection refused (Connection refused)
        at java.net.PlainSocketImpl.socketConnect(Native Method) ~[?:1.8.0_212]
        at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:350) ~[?:1.8.0_212]
        at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:206) ~[?:1.8.0_212]
        at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:188) ~[?:1.8.0_212]
        at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392) ~[?:1.8.0_212]
        at java.net.Socket.connect(Socket.java:589) ~[?:1.8.0_212]
        at org.elasticsearch.mocksocket.MockSocket.access$101(MockSocket.java:32) ~[mocksocket-1.2.jar:?]
        at org.elasticsearch.mocksocket.MockSocket.lambda$connect$0(MockSocket.java:66) ~[mocksocket-1.2.jar:?]
        at java.security.AccessController.doPrivileged(Native Method) ~[?:1.8.0_212]
        at org.elasticsearch.mocksocket.MockSocket.connect(MockSocket.java:65) ~[mocksocket-1.2.jar:?]
        at org.elasticsearch.mocksocket.MockSocket.connect(MockSocket.java:59) ~[mocksocket-1.2.jar:?]
        at org.elasticsearch.transport.MockTcpTransport.lambda$initiateChannel$0(MockTcpTransport.java:190) ~[framework-6.8.0.jar:6.8.0]
        ... 5 more
[2019-06-21T11:37:56,895][INFO ][o.e.e.NodeEnvironment    ] [masterFailOverShouldWork] using [2] data paths, mounts [[/ (/dev/sda1)]], net usable_space [1.3gb], net total_space [29.3gb], types [ext4]
[2019-06-21T11:37:56,916][INFO ][o.e.e.NodeEnvironment    ] [masterFailOverShouldWork] heap size [1.2gb], compressed ordinary object pointers [true]
[2019-06-21T11:37:56,923][INFO ][o.e.n.Node               ] [masterFailOverShouldWork] node name [node_s6], node ID [9mLcvpOrSYOY8tzGqd4M1g]
[2019-06-21T11:37:56,928][INFO ][o.e.n.Node               ] [masterFailOverShouldWork] version[6.8.0], pid[28602], build[unknown/unknown/65b6179/2019-05-15T20:06:13.172855Z], OS[Linux/4.18.0-20-generic/amd64], JVM[Oracle Corporation/OpenJDK 64-Bit Server VM/1.8.0_212/25.212-b03]
[2019-06-21T11:37:56,929][INFO ][o.e.n.Node               ] [masterFailOverShouldWork] JVM arguments []
[2019-06-21T11:37:56,934][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] no modules loaded
[2019-06-21T11:37:56,935][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] loaded plugin [com.automattic.elasticsearch.plugin.StatsdPlugin]
[2019-06-21T11:37:56,935][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] loaded plugin [org.elasticsearch.index.MockEngineFactoryPlugin]
[2019-06-21T11:37:56,936][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] loaded plugin [org.elasticsearch.index.mapper.MockFieldFilterPlugin]
[2019-06-21T11:37:56,936][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] loaded plugin [org.elasticsearch.node.NodeMocksPlugin]
[2019-06-21T11:37:56,937][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] loaded plugin [org.elasticsearch.search.MockSearchService$TestPlugin]
[2019-06-21T11:37:56,938][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] loaded plugin [org.elasticsearch.test.ESIntegTestCase$AssertActionNamePlugin]
[2019-06-21T11:37:56,938][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] loaded plugin [org.elasticsearch.test.ESIntegTestCase$TestSeedPlugin]
[2019-06-21T11:37:56,939][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] loaded plugin [org.elasticsearch.test.discovery.TestZenDiscovery$TestPlugin]
[2019-06-21T11:37:56,939][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] loaded plugin [org.elasticsearch.test.store.MockFSIndexStore$TestPlugin]
[2019-06-21T11:37:56,940][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] loaded plugin [org.elasticsearch.test.transport.MockTransportService$TestPlugin]
[2019-06-21T11:37:56,946][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] loaded plugin [org.elasticsearch.transport.MockTcpTransportPlugin]
[2019-06-21T11:37:57,069][INFO ][o.e.d.DiscoveryModule    ] [masterFailOverShouldWork] using discovery type [test-zen] and host providers [settings, file]
[2019-06-21T11:37:57,208][INFO ][o.e.n.Node               ] [masterFailOverShouldWork] initialized
[2019-06-21T11:37:59,771][INFO ][o.e.c.s.MasterService    ] [node_sm1] zen-disco-elected-as-master ([1] nodes joined)[{node_sm2}{iQGbf2jpRUqidirSGmOd0Q}{aqb88EsXStusCdqRySzfNQ}{127.0.0.1}{127.0.0.1:34709}], reason: new_master {node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515}
[2019-06-21T11:37:59,789][INFO ][o.e.c.s.ClusterApplierService] [node_sd4] detected_master {node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515}, reason: apply cluster state (from master [master {node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515} committed version [22]])
[2019-06-21T11:37:59,789][INFO ][o.e.c.s.ClusterApplierService] [node_sd3] detected_master {node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515}, reason: apply cluster state (from master [master {node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515} committed version [22]])
[2019-06-21T11:37:59,798][INFO ][o.e.c.s.ClusterApplierService] [node_sm2] detected_master {node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515}, reason: apply cluster state (from master [master {node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515} committed version [22]])
[2019-06-21T11:37:59,800][INFO ][o.e.c.s.ClusterApplierService] [node_sd5] detected_master {node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515}, reason: apply cluster state (from master [master {node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515} committed version [22]])
[2019-06-21T11:37:59,819][WARN ][o.e.c.NodeConnectionsService] [node_sm2] failed to connect to node {node_sm0}{9mLcvpOrSYOY8tzGqd4M1g}{aIUM7TCVRRWeApUecsLPuw}{127.0.0.1}{127.0.0.1:39595} (tried [1] times)
org.elasticsearch.transport.ConnectTransportException: [node_sm0][127.0.0.1:39595] connect_exception
        at org.elasticsearch.transport.TcpTransport$ChannelsConnectedListener.onFailure(TcpTransport.java:1309) ~[elasticsearch-6.8.0.jar:6.8.0]
        at org.elasticsearch.action.ActionListener.lambda$toBiConsumer$2(ActionListener.java:100) ~[elasticsearch-6.8.0.jar:6.8.0]
        at org.elasticsearch.common.concurrent.CompletableContext.lambda$addListener$0(CompletableContext.java:42) ~[elasticsearch-core-6.8.0.jar:6.8.0]
        at java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:760) ~[?:1.8.0_212]
        at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:736) ~[?:1.8.0_212]
        at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:474) ~[?:1.8.0_212]
        at java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:1977) ~[?:1.8.0_212]
        at org.elasticsearch.common.concurrent.CompletableContext.completeExceptionally(CompletableContext.java:57) ~[elasticsearch-core-6.8.0.jar:6.8.0]
        at org.elasticsearch.transport.MockTcpTransport.lambda$initiateChannel$0(MockTcpTransport.java:195) ~[framework-6.8.0.jar:6.8.0]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) ~[?:1.8.0_212]
        at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~[?:1.8.0_212]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_212]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_212]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_212]
Caused by: java.net.ConnectException: Connection refused (Connection refused)
        at java.net.PlainSocketImpl.socketConnect(Native Method) ~[?:1.8.0_212]
        at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:350) ~[?:1.8.0_212]
        at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:206) ~[?:1.8.0_212]
        at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:188) ~[?:1.8.0_212]
        at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392) ~[?:1.8.0_212]
        at java.net.Socket.connect(Socket.java:589) ~[?:1.8.0_212]
        at org.elasticsearch.mocksocket.MockSocket.access$101(MockSocket.java:32) ~[mocksocket-1.2.jar:?]
        at org.elasticsearch.mocksocket.MockSocket.lambda$connect$0(MockSocket.java:66) ~[mocksocket-1.2.jar:?]
        at java.security.AccessController.doPrivileged(Native Method) ~[?:1.8.0_212]
        at org.elasticsearch.mocksocket.MockSocket.connect(MockSocket.java:65) ~[mocksocket-1.2.jar:?]
        at org.elasticsearch.mocksocket.MockSocket.connect(MockSocket.java:59) ~[mocksocket-1.2.jar:?]
        at org.elasticsearch.transport.MockTcpTransport.lambda$initiateChannel$0(MockTcpTransport.java:190) ~[framework-6.8.0.jar:6.8.0]
        ... 5 more
[2019-06-21T11:37:59,883][WARN ][o.e.d.z.PublishClusterStateAction] [node_sm1] publishing cluster state with version [22] failed for the following nodes: [[{node_sm0}{9mLcvpOrSYOY8tzGqd4M1g}{aIUM7TCVRRWeApUecsLPuw}{127.0.0.1}{127.0.0.1:39595}]]
[2019-06-21T11:37:59,884][INFO ][o.e.c.s.ClusterApplierService] [node_sm1] new_master {node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515}, reason: apply cluster state (from master [master {node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515} committed version [22] source [zen-disco-elected-as-master ([1] nodes joined)[{node_sm2}{iQGbf2jpRUqidirSGmOd0Q}{aqb88EsXStusCdqRySzfNQ}{127.0.0.1}{127.0.0.1:34709}]]])
[2019-06-21T11:37:59,894][WARN ][o.e.c.NodeConnectionsService] [node_sm1] failed to connect to node {node_sm0}{9mLcvpOrSYOY8tzGqd4M1g}{aIUM7TCVRRWeApUecsLPuw}{127.0.0.1}{127.0.0.1:39595} (tried [1] times)
org.elasticsearch.transport.ConnectTransportException: [node_sm0][127.0.0.1:39595] connect_exception
        at org.elasticsearch.transport.TcpTransport$ChannelsConnectedListener.onFailure(TcpTransport.java:1309) ~[elasticsearch-6.8.0.jar:6.8.0]
        at org.elasticsearch.action.ActionListener.lambda$toBiConsumer$2(ActionListener.java:100) ~[elasticsearch-6.8.0.jar:6.8.0]
        at org.elasticsearch.common.concurrent.CompletableContext.lambda$addListener$0(CompletableContext.java:42) ~[elasticsearch-core-6.8.0.jar:6.8.0]
        at java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:760) ~[?:1.8.0_212]
        at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:736) ~[?:1.8.0_212]
        at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:474) ~[?:1.8.0_212]
        at java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:1977) ~[?:1.8.0_212]
        at org.elasticsearch.common.concurrent.CompletableContext.completeExceptionally(CompletableContext.java:57) ~[elasticsearch-core-6.8.0.jar:6.8.0]
        at org.elasticsearch.transport.MockTcpTransport.lambda$initiateChannel$0(MockTcpTransport.java:195) ~[framework-6.8.0.jar:6.8.0]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) ~[?:1.8.0_212]
        at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~[?:1.8.0_212]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_212]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_212]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_212]
Caused by: java.net.ConnectException: Connection refused (Connection refused)
        at java.net.PlainSocketImpl.socketConnect(Native Method) ~[?:1.8.0_212]
        at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:350) ~[?:1.8.0_212]
        at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:206) ~[?:1.8.0_212]
        at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:188) ~[?:1.8.0_212]
        at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392) ~[?:1.8.0_212]
        at java.net.Socket.connect(Socket.java:589) ~[?:1.8.0_212]
        at org.elasticsearch.mocksocket.MockSocket.access$101(MockSocket.java:32) ~[mocksocket-1.2.jar:?]
        at org.elasticsearch.mocksocket.MockSocket.lambda$connect$0(MockSocket.java:66) ~[mocksocket-1.2.jar:?]
        at java.security.AccessController.doPrivileged(Native Method) ~[?:1.8.0_212]
        at org.elasticsearch.mocksocket.MockSocket.connect(MockSocket.java:65) ~[mocksocket-1.2.jar:?]
        at org.elasticsearch.mocksocket.MockSocket.connect(MockSocket.java:59) ~[mocksocket-1.2.jar:?]
        at org.elasticsearch.transport.MockTcpTransport.lambda$initiateChannel$0(MockTcpTransport.java:190) ~[framework-6.8.0.jar:6.8.0]
        ... 5 more
[2019-06-21T11:37:59,928][INFO ][o.e.c.s.MasterService    ] [node_sm1] zen-disco-node-failed({node_sm0}{9mLcvpOrSYOY8tzGqd4M1g}{aIUM7TCVRRWeApUecsLPuw}{127.0.0.1}{127.0.0.1:39595}), reason(transport disconnected)[{node_sm0}{9mLcvpOrSYOY8tzGqd4M1g}{aIUM7TCVRRWeApUecsLPuw}{127.0.0.1}{127.0.0.1:39595} transport disconnected], reason: removed {{node_sm0}{9mLcvpOrSYOY8tzGqd4M1g}{aIUM7TCVRRWeApUecsLPuw}{127.0.0.1}{127.0.0.1:39595},}
[2019-06-21T11:37:59,936][INFO ][o.e.c.s.ClusterApplierService] [node_sd4] removed {{node_sm0}{9mLcvpOrSYOY8tzGqd4M1g}{aIUM7TCVRRWeApUecsLPuw}{127.0.0.1}{127.0.0.1:39595},}, reason: apply cluster state (from master [master {node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515} committed version [23]])
[2019-06-21T11:37:59,937][INFO ][o.e.c.s.ClusterApplierService] [node_sd3] removed {{node_sm0}{9mLcvpOrSYOY8tzGqd4M1g}{aIUM7TCVRRWeApUecsLPuw}{127.0.0.1}{127.0.0.1:39595},}, reason: apply cluster state (from master [master {node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515} committed version [23]])
[2019-06-21T11:37:59,941][INFO ][o.e.c.s.ClusterApplierService] [node_sd5] removed {{node_sm0}{9mLcvpOrSYOY8tzGqd4M1g}{aIUM7TCVRRWeApUecsLPuw}{127.0.0.1}{127.0.0.1:39595},}, reason: apply cluster state (from master [master {node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515} committed version [23]])
[2019-06-21T11:37:59,939][INFO ][o.e.c.s.ClusterApplierService] [node_sm2] removed {{node_sm0}{9mLcvpOrSYOY8tzGqd4M1g}{aIUM7TCVRRWeApUecsLPuw}{127.0.0.1}{127.0.0.1:39595},}, reason: apply cluster state (from master [master {node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515} committed version [23]])
[2019-06-21T11:37:59,952][INFO ][o.e.c.s.ClusterApplierService] [node_sm1] removed {{node_sm0}{9mLcvpOrSYOY8tzGqd4M1g}{aIUM7TCVRRWeApUecsLPuw}{127.0.0.1}{127.0.0.1:39595},}, reason: apply cluster state (from master [master {node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515} committed version [23] source [zen-disco-node-failed({node_sm0}{9mLcvpOrSYOY8tzGqd4M1g}{aIUM7TCVRRWeApUecsLPuw}{127.0.0.1}{127.0.0.1:39595}), reason(transport disconnected)[{node_sm0}{9mLcvpOrSYOY8tzGqd4M1g}{aIUM7TCVRRWeApUecsLPuw}{127.0.0.1}{127.0.0.1:39595} transport disconnected]]])
[2019-06-21T11:37:59,982][INFO ][o.e.n.Node               ] [integ_7] starting ...
[2019-06-21T11:38:00,009][INFO ][c.a.e.s.StatsdService    ] [integ_7] StatsD reporting triggered every [1s] to host [localhost:12345] with metric prefix [myhost6]
[2019-06-21T11:38:00,009][INFO ][c.a.e.s.StatsdService    ] [node_s6] Cluster state not set yet. Looping...
[2019-06-21T11:38:00,040][INFO ][c.a.e.s.StatsdService    ] [node_s6] Cluster state not set yet. Looping...
[2019-06-21T11:38:00,047][INFO ][o.e.t.TransportService   ] [integ_7] publish_address {127.0.0.1:37765}, bound_addresses {[::1]:45671}, {127.0.0.1:37765}
[2019-06-21T11:38:00,051][INFO ][c.a.e.s.StatsdService    ] [node_s6] Cluster state not set yet. Looping...
[2019-06-21T11:38:00,062][INFO ][c.a.e.s.StatsdService    ] [node_s6] Cluster state not set yet. Looping...
[2019-06-21T11:38:00,075][INFO ][o.e.t.d.MockZenPing      ] [node_s6] pinging using mock zen ping
[2019-06-21T11:38:00,205][INFO ][o.e.c.s.MasterService    ] [node_sm1] zen-disco-node-join[{node_s6}{9mLcvpOrSYOY8tzGqd4M1g}{6rShv_3GQ36Q-mA-N1_ncw}{127.0.0.1}{127.0.0.1:37765}], reason: added {{node_s6}{9mLcvpOrSYOY8tzGqd4M1g}{6rShv_3GQ36Q-mA-N1_ncw}{127.0.0.1}{127.0.0.1:37765},}
[2019-06-21T11:38:00,260][INFO ][o.e.c.s.ClusterApplierService] [node_sm2] added {{node_s6}{9mLcvpOrSYOY8tzGqd4M1g}{6rShv_3GQ36Q-mA-N1_ncw}{127.0.0.1}{127.0.0.1:37765},}, reason: apply cluster state (from master [master {node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515} committed version [25]])
[2019-06-21T11:38:00,264][INFO ][o.e.c.s.ClusterApplierService] [node_sd3] added {{node_s6}{9mLcvpOrSYOY8tzGqd4M1g}{6rShv_3GQ36Q-mA-N1_ncw}{127.0.0.1}{127.0.0.1:37765},}, reason: apply cluster state (from master [master {node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515} committed version [25]])
[2019-06-21T11:38:00,265][INFO ][o.e.c.s.ClusterApplierService] [node_sd4] added {{node_s6}{9mLcvpOrSYOY8tzGqd4M1g}{6rShv_3GQ36Q-mA-N1_ncw}{127.0.0.1}{127.0.0.1:37765},}, reason: apply cluster state (from master [master {node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515} committed version [25]])
[2019-06-21T11:38:00,266][INFO ][o.e.c.s.ClusterApplierService] [node_sd5] added {{node_s6}{9mLcvpOrSYOY8tzGqd4M1g}{6rShv_3GQ36Q-mA-N1_ncw}{127.0.0.1}{127.0.0.1:37765},}, reason: apply cluster state (from master [master {node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515} committed version [25]])
[2019-06-21T11:38:00,300][INFO ][o.e.c.s.ClusterApplierService] [node_s6] detected_master {node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515}, added {{node_sd4}{nolVJCRtRIywePi6dR04_A}{cvP8V-UuTi65m7eVFbtyqA}{127.0.0.1}{127.0.0.1:33953},{node_sd5}{BKRP-ZBsQTyr8oAE7yCU5A}{B5kP-kV-QRKOCAW4kfgSLQ}{127.0.0.1}{127.0.0.1:33651},{node_sm2}{iQGbf2jpRUqidirSGmOd0Q}{aqb88EsXStusCdqRySzfNQ}{127.0.0.1}{127.0.0.1:34709},{node_sd3}{dfQYD9HKRnCVFJcY0yiusA}{NuofZW0lQHqu0ug8-pLy7g}{127.0.0.1}{127.0.0.1:42637},{node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515},}, reason: apply cluster state (from master [master {node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515} committed version [25]])
[2019-06-21T11:38:00,583][INFO ][o.e.n.Node               ] [integ_7] started
[2019-06-21T11:38:00,617][INFO ][o.e.c.s.ClusterApplierService] [node_sm1] added {{node_s6}{9mLcvpOrSYOY8tzGqd4M1g}{6rShv_3GQ36Q-mA-N1_ncw}{127.0.0.1}{127.0.0.1:37765},}, reason: apply cluster state (from master [master {node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515} committed version [25] source [zen-disco-node-join[{node_s6}{9mLcvpOrSYOY8tzGqd4M1g}{6rShv_3GQ36Q-mA-N1_ncw}{127.0.0.1}{127.0.0.1:37765}]]])
[2019-06-21T11:38:00,983][INFO ][o.e.t.s.MockFSIndexStore$Listener] [node_sd3] [cf2440][0] start check index
[2019-06-21T11:38:00,987][INFO ][o.e.t.s.MockFSIndexStore$Listener] [node_sd3] [cf2440][0] end check index
[2019-06-21T11:38:01,126][INFO ][o.e.t.s.MockFSIndexStore$Listener] [node_sd4] [cf2440][1] start check index
[2019-06-21T11:38:01,128][INFO ][o.e.t.s.MockFSIndexStore$Listener] [node_sd4] [cf2440][1] end check index
stopped master
[2019-06-21T11:38:08,660][INFO ][c.a.e.s.t.StatsdPluginIntegrationTest] [masterFailOverShouldWork] [StatsdPluginIntegrationTest#masterFailOverShouldWork]: cleaning up after test
[2019-06-21T11:38:08,689][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] no modules loaded
[2019-06-21T11:38:08,691][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] loaded plugin [org.elasticsearch.transport.MockTcpTransportPlugin]
[2019-06-21T11:38:08,822][INFO ][o.e.c.m.MetaDataDeleteIndexService] [node_sm1] [cf2440/ww5ckwP8T8mbeQYIVCQOXw] deleting index
[2019-06-21T11:38:08,860][INFO ][o.e.t.s.MockFSIndexStore$Listener] [node_s6] [cf2440][0] start check index
[2019-06-21T11:38:08,860][INFO ][o.e.t.s.MockFSIndexStore$Listener] [node_sd5] [cf2440][0] start check index
[2019-06-21T11:38:08,862][INFO ][o.e.t.s.MockFSIndexStore$Listener] [node_sd4] [cf2440][2] start check index
[2019-06-21T11:38:08,862][INFO ][o.e.t.s.MockFSIndexStore$Listener] [node_sd3] [cf2440][1] start check index
[2019-06-21T11:38:08,862][INFO ][o.e.t.s.MockFSIndexStore$Listener] [node_sd5] [cf2440][0] end check index
[2019-06-21T11:38:08,864][INFO ][o.e.t.s.MockFSIndexStore$Listener] [node_sd3] [cf2440][1] end check index
[2019-06-21T11:38:08,871][INFO ][o.e.t.s.MockFSIndexStore$Listener] [node_s6] [cf2440][0] end check index
[2019-06-21T11:38:08,902][INFO ][o.e.t.s.MockFSIndexStore$Listener] [node_s6] [cf2440][1] start check index
[2019-06-21T11:38:08,904][INFO ][o.e.t.s.MockFSIndexStore$Listener] [node_s6] [cf2440][1] end check index
[2019-06-21T11:38:08,908][INFO ][o.e.t.s.MockFSIndexStore$Listener] [node_sd4] [cf2440][2] end check index
[2019-06-21T11:38:08,934][INFO ][o.e.t.s.MockFSIndexStore$Listener] [node_sd5] [cf2440][3] start check index
[2019-06-21T11:38:08,955][INFO ][o.e.t.s.MockFSIndexStore$Listener] [node_sd5] [cf2440][3] end check index
[2019-06-21T11:38:08,982][INFO ][o.e.t.s.MockFSIndexStore$Listener] [node_sd3] [cf2440][2] start check index
[2019-06-21T11:38:08,985][INFO ][o.e.t.s.MockFSIndexStore$Listener] [node_sd4] [cf2440][3] start check index
[2019-06-21T11:38:08,995][INFO ][o.e.t.s.MockFSIndexStore$Listener] [node_sd4] [cf2440][3] end check index
[2019-06-21T11:38:09,001][INFO ][o.e.t.s.MockFSIndexStore$Listener] [node_sd3] [cf2440][2] end check index
[2019-06-21T11:38:09,058][INFO ][o.e.c.m.MetaDataIndexTemplateService] [node_sm1] removing template [random_index_template]
[2019-06-21T11:38:09,086][INFO ][c.a.e.s.t.StatsdPluginIntegrationTest] [masterFailOverShouldWork] [StatsdPluginIntegrationTest#masterFailOverShouldWork]: cleaned up after test
[2019-06-21T11:38:09,087][INFO ][c.a.e.s.t.StatsdPluginIntegrationTest] [masterFailOverShouldWork] after test
Waiting for cleanup
java.net.SocketException: Socket closed
        at java.net.PlainDatagramSocketImpl.peekData(Native Method)
[2019-06-21T11:38:19,092][INFO ][o.e.n.Node               ] [suite] stopping ...
[2019-06-21T11:38:19,096][INFO ][o.e.c.s.MasterService    ] [node_sm1] zen-disco-node-left({node_s6}{9mLcvpOrSYOY8tzGqd4M1g}{6rShv_3GQ36Q-mA-N1_ncw}{127.0.0.1}{127.0.0.1:37765}), reason(left)[{node_s6}{9mLcvpOrSYOY8tzGqd4M1g}{6rShv_3GQ36Q-mA-N1_ncw}{127.0.0.1}{127.0.0.1:37765} left], reason: removed {{node_s6}{9mLcvpOrSYOY8tzGqd4M1g}{6rShv_3GQ36Q-mA-N1_ncw}{127.0.0.1}{127.0.0.1:37765},}
        at java.net.DatagramSocket.receive(DatagramSocket.java:743)
        at com.automattic.elasticsearch.statsd.test.StatsdMockServer.run(StatsdMockServer.java:40)
[2019-06-21T11:38:19,102][INFO ][o.e.c.s.ClusterApplierService] [node_sm2] removed {{node_s6}{9mLcvpOrSYOY8tzGqd4M1g}{6rShv_3GQ36Q-mA-N1_ncw}{127.0.0.1}{127.0.0.1:37765},}, reason: apply cluster state (from master [master {node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515} committed version [30]])
[2019-06-21T11:38:19,102][INFO ][o.e.c.s.ClusterApplierService] [node_sd5] removed {{node_s6}{9mLcvpOrSYOY8tzGqd4M1g}{6rShv_3GQ36Q-mA-N1_ncw}{127.0.0.1}{127.0.0.1:37765},}, reason: apply cluster state (from master [master {node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515} committed version [30]])
[2019-06-21T11:38:19,109][ERROR][c.a.e.s.StatsdService    ] [node_s6] Exiting StatsdReporterThread
[2019-06-21T11:38:19,109][INFO ][c.a.e.s.StatsdService    ] [suite] StatsD reporter stopped
[2019-06-21T11:38:19,115][INFO ][o.e.n.Node               ] [suite] stopped
[2019-06-21T11:38:19,115][INFO ][o.e.n.Node               ] [suite] closing ...
[2019-06-21T11:38:19,104][INFO ][o.e.c.s.ClusterApplierService] [node_sd3] removed {{node_s6}{9mLcvpOrSYOY8tzGqd4M1g}{6rShv_3GQ36Q-mA-N1_ncw}{127.0.0.1}{127.0.0.1:37765},}, reason: apply cluster state (from master [master {node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515} committed version [30]])
[2019-06-21T11:38:19,103][INFO ][o.e.c.s.ClusterApplierService] [node_sd4] removed {{node_s6}{9mLcvpOrSYOY8tzGqd4M1g}{6rShv_3GQ36Q-mA-N1_ncw}{127.0.0.1}{127.0.0.1:37765},}, reason: apply cluster state (from master [master {node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515} committed version [30]])
[2019-06-21T11:38:19,121][INFO ][o.e.c.s.ClusterApplierService] [node_sm1] removed {{node_s6}{9mLcvpOrSYOY8tzGqd4M1g}{6rShv_3GQ36Q-mA-N1_ncw}{127.0.0.1}{127.0.0.1:37765},}, reason: apply cluster state (from master [master {node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515} committed version [30] source [zen-disco-node-left({node_s6}{9mLcvpOrSYOY8tzGqd4M1g}{6rShv_3GQ36Q-mA-N1_ncw}{127.0.0.1}{127.0.0.1:37765}), reason(left)[{node_s6}{9mLcvpOrSYOY8tzGqd4M1g}{6rShv_3GQ36Q-mA-N1_ncw}{127.0.0.1}{127.0.0.1:37765} left]]])
[2019-06-21T11:38:19,133][INFO ][o.e.n.Node               ] [suite] closed
[2019-06-21T11:38:19,151][INFO ][o.e.n.Node               ] [suite] stopping ...
[2019-06-21T11:38:19,155][INFO ][o.e.c.s.MasterService    ] [node_sm1] zen-disco-node-left({node_sd3}{dfQYD9HKRnCVFJcY0yiusA}{NuofZW0lQHqu0ug8-pLy7g}{127.0.0.1}{127.0.0.1:42637}), reason(left)[{node_sd3}{dfQYD9HKRnCVFJcY0yiusA}{NuofZW0lQHqu0ug8-pLy7g}{127.0.0.1}{127.0.0.1:42637} left], reason: removed {{node_sd3}{dfQYD9HKRnCVFJcY0yiusA}{NuofZW0lQHqu0ug8-pLy7g}{127.0.0.1}{127.0.0.1:42637},}
[2019-06-21T11:38:19,164][INFO ][o.e.c.s.ClusterApplierService] [node_sd5] removed {{node_sd3}{dfQYD9HKRnCVFJcY0yiusA}{NuofZW0lQHqu0ug8-pLy7g}{127.0.0.1}{127.0.0.1:42637},}, reason: apply cluster state (from master [master {node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515} committed version [31]])
[2019-06-21T11:38:19,166][INFO ][o.e.c.s.ClusterApplierService] [node_sm2] removed {{node_sd3}{dfQYD9HKRnCVFJcY0yiusA}{NuofZW0lQHqu0ug8-pLy7g}{127.0.0.1}{127.0.0.1:42637},}, reason: apply cluster state (from master [master {node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515} committed version [31]])
[2019-06-21T11:38:19,168][INFO ][o.e.c.s.ClusterApplierService] [node_sd4] removed {{node_sd3}{dfQYD9HKRnCVFJcY0yiusA}{NuofZW0lQHqu0ug8-pLy7g}{127.0.0.1}{127.0.0.1:42637},}, reason: apply cluster state (from master [master {node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515} committed version [31]])
[2019-06-21T11:38:19,170][INFO ][o.e.c.s.ClusterApplierService] [node_sm1] removed {{node_sd3}{dfQYD9HKRnCVFJcY0yiusA}{NuofZW0lQHqu0ug8-pLy7g}{127.0.0.1}{127.0.0.1:42637},}, reason: apply cluster state (from master [master {node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515} committed version [31] source [zen-disco-node-left({node_sd3}{dfQYD9HKRnCVFJcY0yiusA}{NuofZW0lQHqu0ug8-pLy7g}{127.0.0.1}{127.0.0.1:42637}), reason(left)[{node_sd3}{dfQYD9HKRnCVFJcY0yiusA}{NuofZW0lQHqu0ug8-pLy7g}{127.0.0.1}{127.0.0.1:42637} left]]])
[2019-06-21T11:38:19,198][INFO ][c.a.e.s.StatsdService    ] [suite] StatsD reporter stopped
[2019-06-21T11:38:19,198][INFO ][o.e.n.Node               ] [suite] stopped
[2019-06-21T11:38:19,198][ERROR][c.a.e.s.StatsdService    ] [node_sd3] Exiting StatsdReporterThread
[2019-06-21T11:38:19,199][INFO ][o.e.n.Node               ] [suite] closing ...
[2019-06-21T11:38:19,215][INFO ][o.e.n.Node               ] [suite] closed
[2019-06-21T11:38:19,224][INFO ][o.e.n.Node               ] [suite] stopping ...
[2019-06-21T11:38:19,229][INFO ][o.e.c.s.MasterService    ] [node_sm1] zen-disco-node-left({node_sd4}{nolVJCRtRIywePi6dR04_A}{cvP8V-UuTi65m7eVFbtyqA}{127.0.0.1}{127.0.0.1:33953}), reason(left)[{node_sd4}{nolVJCRtRIywePi6dR04_A}{cvP8V-UuTi65m7eVFbtyqA}{127.0.0.1}{127.0.0.1:33953} left], reason: removed {{node_sd4}{nolVJCRtRIywePi6dR04_A}{cvP8V-UuTi65m7eVFbtyqA}{127.0.0.1}{127.0.0.1:33953},}
[2019-06-21T11:38:19,233][INFO ][o.e.c.s.ClusterApplierService] [node_sd5] removed {{node_sd4}{nolVJCRtRIywePi6dR04_A}{cvP8V-UuTi65m7eVFbtyqA}{127.0.0.1}{127.0.0.1:33953},}, reason: apply cluster state (from master [master {node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515} committed version [32]])
[2019-06-21T11:38:19,235][INFO ][o.e.c.s.ClusterApplierService] [node_sm2] removed {{node_sd4}{nolVJCRtRIywePi6dR04_A}{cvP8V-UuTi65m7eVFbtyqA}{127.0.0.1}{127.0.0.1:33953},}, reason: apply cluster state (from master [master {node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515} committed version [32]])
[2019-06-21T11:38:19,238][INFO ][o.e.c.s.ClusterApplierService] [node_sm1] removed {{node_sd4}{nolVJCRtRIywePi6dR04_A}{cvP8V-UuTi65m7eVFbtyqA}{127.0.0.1}{127.0.0.1:33953},}, reason: apply cluster state (from master [master {node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515} committed version [32] source [zen-disco-node-left({node_sd4}{nolVJCRtRIywePi6dR04_A}{cvP8V-UuTi65m7eVFbtyqA}{127.0.0.1}{127.0.0.1:33953}), reason(left)[{node_sd4}{nolVJCRtRIywePi6dR04_A}{cvP8V-UuTi65m7eVFbtyqA}{127.0.0.1}{127.0.0.1:33953} left]]])
[2019-06-21T11:38:19,252][INFO ][c.a.e.s.StatsdService    ] [suite] StatsD reporter stopped
[2019-06-21T11:38:19,252][ERROR][c.a.e.s.StatsdService    ] [node_sd4] Exiting StatsdReporterThread
[2019-06-21T11:38:19,254][INFO ][o.e.n.Node               ] [suite] stopped
[2019-06-21T11:38:19,256][INFO ][o.e.n.Node               ] [suite] closing ...
[2019-06-21T11:38:19,270][INFO ][o.e.n.Node               ] [suite] closed
[2019-06-21T11:38:19,285][INFO ][o.e.n.Node               ] [suite] stopping ...
[2019-06-21T11:38:19,287][INFO ][o.e.c.s.MasterService    ] [node_sm1] zen-disco-node-left({node_sd5}{BKRP-ZBsQTyr8oAE7yCU5A}{B5kP-kV-QRKOCAW4kfgSLQ}{127.0.0.1}{127.0.0.1:33651}), reason(left)[{node_sd5}{BKRP-ZBsQTyr8oAE7yCU5A}{B5kP-kV-QRKOCAW4kfgSLQ}{127.0.0.1}{127.0.0.1:33651} left], reason: removed {{node_sd5}{BKRP-ZBsQTyr8oAE7yCU5A}{B5kP-kV-QRKOCAW4kfgSLQ}{127.0.0.1}{127.0.0.1:33651},}
[2019-06-21T11:38:19,289][INFO ][o.e.c.s.ClusterApplierService] [node_sm2] removed {{node_sd5}{BKRP-ZBsQTyr8oAE7yCU5A}{B5kP-kV-QRKOCAW4kfgSLQ}{127.0.0.1}{127.0.0.1:33651},}, reason: apply cluster state (from master [master {node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515} committed version [33]])
[2019-06-21T11:38:19,291][INFO ][o.e.c.s.ClusterApplierService] [node_sm1] removed {{node_sd5}{BKRP-ZBsQTyr8oAE7yCU5A}{B5kP-kV-QRKOCAW4kfgSLQ}{127.0.0.1}{127.0.0.1:33651},}, reason: apply cluster state (from master [master {node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515} committed version [33] source [zen-disco-node-left({node_sd5}{BKRP-ZBsQTyr8oAE7yCU5A}{B5kP-kV-QRKOCAW4kfgSLQ}{127.0.0.1}{127.0.0.1:33651}), reason(left)[{node_sd5}{BKRP-ZBsQTyr8oAE7yCU5A}{B5kP-kV-QRKOCAW4kfgSLQ}{127.0.0.1}{127.0.0.1:33651} left]]])
[2019-06-21T11:38:19,313][INFO ][c.a.e.s.StatsdService    ] [suite] StatsD reporter stopped
[2019-06-21T11:38:19,313][ERROR][c.a.e.s.StatsdService    ] [node_sd5] Exiting StatsdReporterThread
[2019-06-21T11:38:19,313][INFO ][o.e.n.Node               ] [suite] stopped
[2019-06-21T11:38:19,314][INFO ][o.e.n.Node               ] [suite] closing ...
[2019-06-21T11:38:19,323][INFO ][o.e.n.Node               ] [suite] closed
[2019-06-21T11:38:19,326][INFO ][o.e.n.Node               ] [suite] stopping ...
[2019-06-21T11:38:19,328][INFO ][o.e.d.z.ZenDiscovery     ] [node_sm2] master_left [{node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515}], reason [shut_down]
[2019-06-21T11:38:19,329][WARN ][o.e.d.z.ZenDiscovery     ] [node_sm2] master left (reason = shut_down), current nodes: nodes: 
   {node_sm2}{iQGbf2jpRUqidirSGmOd0Q}{aqb88EsXStusCdqRySzfNQ}{127.0.0.1}{127.0.0.1:34709}, local
   {node_sm1}{gkaIFYk4TDyw2zAE9LqX7g}{KViu_H1ZSlild0CONr7Yyg}{127.0.0.1}{127.0.0.1:42515}, master

[2019-06-21T11:38:19,331][INFO ][o.e.t.d.MockZenPing      ] [node_sm2] pinging using mock zen ping
[2019-06-21T11:38:19,336][ERROR][c.a.e.s.StatsdService    ] [node_sm1] Exiting StatsdReporterThread
[2019-06-21T11:38:19,336][INFO ][c.a.e.s.StatsdService    ] [suite] StatsD reporter stopped
[2019-06-21T11:38:19,336][INFO ][o.e.n.Node               ] [suite] stopped
[2019-06-21T11:38:19,337][INFO ][o.e.n.Node               ] [suite] closing ...
[2019-06-21T11:38:19,340][INFO ][o.e.n.Node               ] [suite] closed
[2019-06-21T11:38:19,344][INFO ][o.e.n.Node               ] [suite] stopping ...
[2019-06-21T11:38:19,345][WARN ][o.e.d.z.ZenDiscovery     ] [node_sm2] not enough master nodes discovered during pinging (found [[Candidate{node={node_sm2}{iQGbf2jpRUqidirSGmOd0Q}{aqb88EsXStusCdqRySzfNQ}{127.0.0.1}{127.0.0.1:34709}, clusterStateVersion=33}]], but needed [2]), pinging again
[2019-06-21T11:38:19,352][ERROR][c.a.e.s.StatsdService    ] [node_sm2] Exiting StatsdReporterThread
[2019-06-21T11:38:19,352][INFO ][c.a.e.s.StatsdService    ] [suite] StatsD reporter stopped
[2019-06-21T11:38:19,353][INFO ][o.e.n.Node               ] [suite] stopped
[2019-06-21T11:38:19,353][INFO ][o.e.n.Node               ] [suite] closing ...
[2019-06-21T11:38:19,369][INFO ][o.e.n.Node               ] [suite] closed
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 43.668 sec

Results :

Tests run: 2, Failures: 0, Errors: 0, Skipped: 0

[INFO] 
[INFO] --- maven-jar-plugin:2.4:jar (default-jar) @ elasticsearch-statsd ---
[INFO] Building jar: /home/ph/projects/elasticsearch-statsd-plugin/target/elasticsearch-statsd-6.8.0.0.jar
[INFO] 
[INFO] --- maven-assembly-plugin:2.3:single (default) @ elasticsearch-statsd ---
[INFO] Reading assembly descriptor: /home/ph/projects/elasticsearch-statsd-plugin/src/main/assemblies/plugin.xml
[WARNING] The following patterns were never triggered in this artifact exclusion filter:
o  'org.elasticsearch:elasticsearch'

[INFO] Building zip: /home/ph/projects/elasticsearch-statsd-plugin/target/releases/elasticsearch-statsd-6.8.0.0.zip
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  53.818 s
[INFO] Finished at: 2019-06-21T12:38:22+03:00
[INFO] ------------------------------------------------------------------------
```