### PR TITLE
Upgrade Elastic base-tech version to 6.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The data sent to the StatsD server tries to be roughly equivalent to the [Indice
 
 | Elasticsearch  | Plugin         | Release date |
 | -------------- | -------------- | ------------ |
+| 6.8.1          | 6.8.1.0        | Jun 21, 2019 |
 | 6.8.0          | 6.8.0.0        | Jun 21, 2019 |
 | 6.6.1          | 6.6.1.0        | Mar 11, 2019 |
 | 6.5.0          | 6.5.0.0        | Jan 2,  2019 |
@@ -86,12 +87,12 @@ The plugin artifacts are published to Maven Central and Github. To install a pre
 From Github:
 
 ```
-./bin/elasticsearch-plugin install https://github.com/Automattic/elasticsearch-statsd-plugin/releases/download/6.8.0.0/elasticsearch-statsd-6.8.0.0.zip
+./bin/elasticsearch-plugin install https://github.com/Automattic/elasticsearch-statsd-plugin/releases/download/6.8.1.0/elasticsearch-statsd-6.8.1.0.zip
 ```
 
 From Maven Central:
 ```
-./bin/elasticsearch-plugin install http://repo1.maven.org/maven2/com/automattic/elasticsearch-statsd/6.8.0.0/elasticsearch-statsd-6.8.0.0.zip
+./bin/elasticsearch-plugin install http://repo1.maven.org/maven2/com/automattic/elasticsearch-statsd/6.8.1.0/elasticsearch-statsd-6.8.1.0.zip
 ```
 
 Change the version to match your ES version. For ES `x.y.z` the version is `x.y.z.0`
@@ -107,7 +108,7 @@ mvn clean package -Djava.security.policy=src/test/resources/plugin-security-test
 Once we have the artifact, install it with the following command:
 
 ```
-bin/elasticsearch-plugin install file:///absolute/path/to/current/dir/target/releases/elasticsearch-statsd-6.8.0.0.zip
+bin/elasticsearch-plugin install file:///absolute/path/to/current/dir/target/releases/elasticsearch-statsd-6.8.1.0.zip
 ```
 
 ## Installation Elasticsearch 5.x

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.automattic</groupId>
     <artifactId>elasticsearch-statsd</artifactId>
-    <version>6.8.0.0</version>
+    <version>6.8.1.0</version>
     <packaging>jar</packaging>
 
     <name>elasticsearch-statsd</name>
@@ -46,7 +46,7 @@
     </developers>
 
     <properties>
-        <elasticsearch.version>6.8.0</elasticsearch.version>
+        <elasticsearch.version>6.8.1</elasticsearch.version>
         <junit.version>4.12</junit.version>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
```
ph@ph-VirtualBox:~/projects/elasticsearch-statsd-plugin$ mvn clean package -Djava.security.policy=src/test/resources/plugin-security-test.policy -Dtests.gradle=false
[INFO] Scanning for projects...
[INFO] 
[INFO] ----------------< com.automattic:elasticsearch-statsd >-----------------
[INFO] Building elasticsearch-statsd 6.8.1.0
[INFO] --------------------------------[ jar ]---------------------------------
Downloading from central: https://repo.maven.apache.org/maven2/org/elasticsearch/elasticsearch/6.8.1/elasticsearch-6.8.1.jar
Downloaded from central: https://repo.maven.apache.org/maven2/org/elasticsearch/elasticsearch/6.8.1/elasticsearch-6.8.1.jar (11 MB at 3.3 MB/s)
[INFO] 
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ elasticsearch-statsd ---
[INFO] Deleting /home/ph/projects/elasticsearch-statsd-plugin/target
[INFO] 
[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ elasticsearch-statsd ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] skip non existing resourceDirectory /home/ph/projects/elasticsearch-statsd-plugin/src/main/resources
[INFO] 
[INFO] --- maven-compiler-plugin:2.3.2:compile (default-compile) @ elasticsearch-statsd ---
[INFO] Compiling 7 source files to /home/ph/projects/elasticsearch-statsd-plugin/target/classes
[INFO] 
[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ elasticsearch-statsd ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 2 resources
[INFO] 
[INFO] --- maven-compiler-plugin:2.3.2:testCompile (default-testCompile) @ elasticsearch-statsd ---
[INFO] Compiling 3 source files to /home/ph/projects/elasticsearch-statsd-plugin/target/test-classes
[INFO] 
[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ elasticsearch-statsd ---
[INFO] Surefire report directory: /home/ph/projects/elasticsearch-statsd-plugin/target/surefire-reports

-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running com.automattic.elasticsearch.statsd.test.StatsdPluginIntegrationTest
[2019-06-21T18:12:38,776][INFO ][c.a.e.s.t.StatsdPluginIntegrationTest] [masterFailOverShouldWork] before test
[2019-06-21T18:12:38,784][INFO ][c.a.e.s.t.StatsdPluginIntegrationTest] [masterFailOverShouldWork] [StatsdPluginIntegrationTest#masterFailOverShouldWork]: setting up test
[2019-06-21T18:12:38,840][INFO ][o.e.t.InternalTestCluster] [masterFailOverShouldWork] Setup InternalTestCluster [SUITE-CHILD_VM=[0]-CLUSTER_SEED=[3249951889962147308]-HASH=[B8BD346E542F]-cluster] with seed [2D1A2606624D9DEC] using [1] dedicated masters, [3] (data) nodes and [0] coord only nodes (min_master_nodes are [auto-managed])
[2019-06-21T18:12:39,661][INFO ][o.e.e.NodeEnvironment    ] [masterFailOverShouldWork] using [1] data paths, mounts [[/ (/dev/sda1)]], net usable_space [7.6gb], net total_space [29.3gb], types [ext4]
[2019-06-21T18:12:39,676][INFO ][o.e.e.NodeEnvironment    ] [masterFailOverShouldWork] heap size [1.2gb], compressed ordinary object pointers [true]
[2019-06-21T18:12:39,687][INFO ][o.e.n.Node               ] [masterFailOverShouldWork] node name [node_sm0], node ID [jDkU3_Y6TQq9nWYRfemB2w]
[2019-06-21T18:12:39,692][INFO ][o.e.n.Node               ] [masterFailOverShouldWork] version[6.8.1], pid[14254], build[unknown/unknown/1fad4e1/2019-06-18T13:16:52.517138Z], OS[Linux/4.18.0-20-generic/amd64], JVM[Oracle Corporation/OpenJDK 64-Bit Server VM/1.8.0_212/25.212-b03]
[2019-06-21T18:12:39,697][INFO ][o.e.n.Node               ] [masterFailOverShouldWork] JVM arguments []
[2019-06-21T18:12:39,714][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] no modules loaded
[2019-06-21T18:12:39,719][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] loaded plugin [com.automattic.elasticsearch.plugin.StatsdPlugin]
[2019-06-21T18:12:39,724][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] loaded plugin [org.elasticsearch.test.ESIntegTestCase$AssertActionNamePlugin]
[2019-06-21T18:12:39,732][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] loaded plugin [org.elasticsearch.test.ESIntegTestCase$TestSeedPlugin]
[2019-06-21T18:12:39,736][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] loaded plugin [org.elasticsearch.test.discovery.TestZenDiscovery$TestPlugin]
[2019-06-21T18:12:39,739][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] loaded plugin [org.elasticsearch.transport.MockTcpTransportPlugin]
[2019-06-21T18:12:40,962][WARN ][o.e.d.c.s.Settings       ] [masterFailOverShouldWork] [http.enabled] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version.
[2019-06-21T18:12:40,983][WARN ][o.e.d.c.s.Settings       ] [masterFailOverShouldWork] [http.pipelining] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version.
[2019-06-21T18:12:42,300][INFO ][o.e.d.DiscoveryModule    ] [masterFailOverShouldWork] using discovery type [test-zen] and host providers [settings, file]
[2019-06-21T18:12:43,311][INFO ][o.e.n.Node               ] [masterFailOverShouldWork] initialized
[2019-06-21T18:12:43,325][INFO ][o.e.e.NodeEnvironment    ] [masterFailOverShouldWork] using [1] data paths, mounts [[/ (/dev/sda1)]], net usable_space [7.6gb], net total_space [29.3gb], types [ext4]
[2019-06-21T18:12:43,334][INFO ][o.e.e.NodeEnvironment    ] [masterFailOverShouldWork] heap size [1.2gb], compressed ordinary object pointers [true]
[2019-06-21T18:12:43,337][INFO ][o.e.n.Node               ] [masterFailOverShouldWork] node name [node_sd1], node ID [Adp5TIalTH6GZrVGvUi5Ww]
[2019-06-21T18:12:43,340][INFO ][o.e.n.Node               ] [masterFailOverShouldWork] version[6.8.1], pid[14254], build[unknown/unknown/1fad4e1/2019-06-18T13:16:52.517138Z], OS[Linux/4.18.0-20-generic/amd64], JVM[Oracle Corporation/OpenJDK 64-Bit Server VM/1.8.0_212/25.212-b03]
[2019-06-21T18:12:43,343][INFO ][o.e.n.Node               ] [masterFailOverShouldWork] JVM arguments []
[2019-06-21T18:12:43,345][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] no modules loaded
[2019-06-21T18:12:43,347][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] loaded plugin [com.automattic.elasticsearch.plugin.StatsdPlugin]
[2019-06-21T18:12:43,349][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] loaded plugin [org.elasticsearch.test.ESIntegTestCase$AssertActionNamePlugin]
[2019-06-21T18:12:43,350][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] loaded plugin [org.elasticsearch.test.ESIntegTestCase$TestSeedPlugin]
[2019-06-21T18:12:43,353][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] loaded plugin [org.elasticsearch.test.discovery.TestZenDiscovery$TestPlugin]
[2019-06-21T18:12:43,354][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] loaded plugin [org.elasticsearch.transport.MockTcpTransportPlugin]
[2019-06-21T18:12:43,414][INFO ][o.e.d.DiscoveryModule    ] [masterFailOverShouldWork] using discovery type [test-zen] and host providers [settings, file]
[2019-06-21T18:12:43,508][INFO ][o.e.n.Node               ] [masterFailOverShouldWork] initialized
[2019-06-21T18:12:43,519][INFO ][o.e.e.NodeEnvironment    ] [masterFailOverShouldWork] using [1] data paths, mounts [[/ (/dev/sda1)]], net usable_space [7.6gb], net total_space [29.3gb], types [ext4]
[2019-06-21T18:12:43,536][INFO ][o.e.e.NodeEnvironment    ] [masterFailOverShouldWork] heap size [1.2gb], compressed ordinary object pointers [true]
[2019-06-21T18:12:43,560][INFO ][o.e.n.Node               ] [masterFailOverShouldWork] node name [node_sd2], node ID [Uh7CwNsmRUezdtRGOKrfEg]
[2019-06-21T18:12:43,561][INFO ][o.e.n.Node               ] [masterFailOverShouldWork] version[6.8.1], pid[14254], build[unknown/unknown/1fad4e1/2019-06-18T13:16:52.517138Z], OS[Linux/4.18.0-20-generic/amd64], JVM[Oracle Corporation/OpenJDK 64-Bit Server VM/1.8.0_212/25.212-b03]
[2019-06-21T18:12:43,564][INFO ][o.e.n.Node               ] [masterFailOverShouldWork] JVM arguments []
[2019-06-21T18:12:43,571][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] no modules loaded
[2019-06-21T18:12:43,573][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] loaded plugin [com.automattic.elasticsearch.plugin.StatsdPlugin]
[2019-06-21T18:12:43,578][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] loaded plugin [org.elasticsearch.test.ESIntegTestCase$AssertActionNamePlugin]
[2019-06-21T18:12:43,579][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] loaded plugin [org.elasticsearch.test.ESIntegTestCase$TestSeedPlugin]
[2019-06-21T18:12:43,580][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] loaded plugin [org.elasticsearch.test.discovery.TestZenDiscovery$TestPlugin]
[2019-06-21T18:12:43,582][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] loaded plugin [org.elasticsearch.transport.MockTcpTransportPlugin]
[2019-06-21T18:12:43,711][INFO ][o.e.d.DiscoveryModule    ] [masterFailOverShouldWork] using discovery type [test-zen] and host providers [settings, file]
[2019-06-21T18:12:43,839][INFO ][o.e.n.Node               ] [masterFailOverShouldWork] initialized
[2019-06-21T18:12:43,883][INFO ][o.e.e.NodeEnvironment    ] [masterFailOverShouldWork] using [1] data paths, mounts [[/ (/dev/sda1)]], net usable_space [7.6gb], net total_space [29.3gb], types [ext4]
[2019-06-21T18:12:43,894][INFO ][o.e.e.NodeEnvironment    ] [masterFailOverShouldWork] heap size [1.2gb], compressed ordinary object pointers [true]
[2019-06-21T18:12:43,903][INFO ][o.e.n.Node               ] [masterFailOverShouldWork] node name [node_sd3], node ID [5wqF7w5hSXS16Fj3rfBSdg]
[2019-06-21T18:12:43,914][INFO ][o.e.n.Node               ] [masterFailOverShouldWork] version[6.8.1], pid[14254], build[unknown/unknown/1fad4e1/2019-06-18T13:16:52.517138Z], OS[Linux/4.18.0-20-generic/amd64], JVM[Oracle Corporation/OpenJDK 64-Bit Server VM/1.8.0_212/25.212-b03]
[2019-06-21T18:12:43,923][INFO ][o.e.n.Node               ] [masterFailOverShouldWork] JVM arguments []
[2019-06-21T18:12:43,924][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] no modules loaded
[2019-06-21T18:12:43,924][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] loaded plugin [com.automattic.elasticsearch.plugin.StatsdPlugin]
[2019-06-21T18:12:43,925][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] loaded plugin [org.elasticsearch.test.ESIntegTestCase$AssertActionNamePlugin]
[2019-06-21T18:12:43,925][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] loaded plugin [org.elasticsearch.test.ESIntegTestCase$TestSeedPlugin]
[2019-06-21T18:12:43,937][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] loaded plugin [org.elasticsearch.test.discovery.TestZenDiscovery$TestPlugin]
[2019-06-21T18:12:43,941][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] loaded plugin [org.elasticsearch.transport.MockTcpTransportPlugin]
[2019-06-21T18:12:44,064][INFO ][o.e.d.DiscoveryModule    ] [masterFailOverShouldWork] using discovery type [test-zen] and host providers [settings, file]
[2019-06-21T18:12:44,225][INFO ][o.e.n.Node               ] [masterFailOverShouldWork] initialized
[2019-06-21T18:12:44,309][INFO ][o.e.n.Node               ] [integ_3] starting ...
[2019-06-21T18:12:44,316][INFO ][o.e.n.Node               ] [integ_2] starting ...
[2019-06-21T18:12:44,317][INFO ][o.e.n.Node               ] [integ_4] starting ...
[2019-06-21T18:12:44,317][INFO ][o.e.n.Node               ] [integ_1] starting ...
[2019-06-21T18:12:44,331][INFO ][c.a.e.s.StatsdService    ] [integ_2] StatsD reporting triggered every [1s] to host [localhost:12345] with metric prefix [myhost1]
[2019-06-21T18:12:44,334][INFO ][c.a.e.s.StatsdService    ] [node_sd1] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,342][INFO ][c.a.e.s.StatsdService    ] [integ_1] StatsD reporting triggered every [1s] to host [localhost:12345] with metric prefix [myhost0]
[2019-06-21T18:12:44,350][INFO ][c.a.e.s.StatsdService    ] [integ_4] StatsD reporting triggered every [1s] to host [localhost:12345] with metric prefix [myhost3]
[2019-06-21T18:12:44,350][INFO ][c.a.e.s.StatsdService    ] [node_sm0] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,352][INFO ][c.a.e.s.StatsdService    ] [node_sd3] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,354][INFO ][c.a.e.s.StatsdService    ] [node_sd1] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,363][INFO ][c.a.e.s.StatsdService    ] [node_sm0] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,365][INFO ][c.a.e.s.StatsdService    ] [integ_3] StatsD reporting triggered every [1s] to host [localhost:12345] with metric prefix [myhost2]
[2019-06-21T18:12:44,372][INFO ][c.a.e.s.StatsdService    ] [node_sd1] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,373][INFO ][c.a.e.s.StatsdService    ] [node_sd3] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,374][INFO ][c.a.e.s.StatsdService    ] [node_sm0] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,366][INFO ][c.a.e.s.StatsdService    ] [node_sd2] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,384][INFO ][c.a.e.s.StatsdService    ] [node_sd3] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,383][INFO ][c.a.e.s.StatsdService    ] [node_sd1] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,385][INFO ][c.a.e.s.StatsdService    ] [node_sm0] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,395][INFO ][c.a.e.s.StatsdService    ] [node_sd1] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,396][INFO ][c.a.e.s.StatsdService    ] [node_sd2] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,395][INFO ][c.a.e.s.StatsdService    ] [node_sd3] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,397][INFO ][c.a.e.s.StatsdService    ] [node_sm0] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,406][INFO ][c.a.e.s.StatsdService    ] [node_sd1] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,406][INFO ][c.a.e.s.StatsdService    ] [node_sd2] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,407][INFO ][c.a.e.s.StatsdService    ] [node_sd3] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,407][INFO ][c.a.e.s.StatsdService    ] [node_sm0] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,416][INFO ][c.a.e.s.StatsdService    ] [node_sd1] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,417][INFO ][c.a.e.s.StatsdService    ] [node_sd2] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,419][INFO ][c.a.e.s.StatsdService    ] [node_sm0] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,418][INFO ][c.a.e.s.StatsdService    ] [node_sd3] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,427][INFO ][c.a.e.s.StatsdService    ] [node_sd1] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,430][INFO ][c.a.e.s.StatsdService    ] [node_sd2] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,430][INFO ][c.a.e.s.StatsdService    ] [node_sm0] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,431][INFO ][c.a.e.s.StatsdService    ] [node_sd3] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,438][INFO ][c.a.e.s.StatsdService    ] [node_sd1] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,440][INFO ][c.a.e.s.StatsdService    ] [node_sd2] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,441][INFO ][c.a.e.s.StatsdService    ] [node_sm0] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,442][INFO ][c.a.e.s.StatsdService    ] [node_sd3] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,449][INFO ][c.a.e.s.StatsdService    ] [node_sd1] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,452][INFO ][c.a.e.s.StatsdService    ] [node_sd2] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,453][INFO ][c.a.e.s.StatsdService    ] [node_sm0] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,454][INFO ][c.a.e.s.StatsdService    ] [node_sd3] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,459][INFO ][o.e.t.TransportService   ] [integ_1] publish_address {127.0.0.1:46127}, bound_addresses {[::1]:39429}, {127.0.0.1:46127}
[2019-06-21T18:12:44,460][INFO ][c.a.e.s.StatsdService    ] [node_sd1] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,463][INFO ][c.a.e.s.StatsdService    ] [node_sd2] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,463][INFO ][c.a.e.s.StatsdService    ] [node_sm0] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,464][INFO ][c.a.e.s.StatsdService    ] [node_sd3] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,470][INFO ][c.a.e.s.StatsdService    ] [node_sd1] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,474][INFO ][c.a.e.s.StatsdService    ] [node_sd2] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,475][INFO ][c.a.e.s.StatsdService    ] [node_sm0] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,480][INFO ][c.a.e.s.StatsdService    ] [node_sd3] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,484][INFO ][o.e.t.TransportService   ] [integ_2] publish_address {127.0.0.1:45319}, bound_addresses {[::1]:33841}, {127.0.0.1:45319}
[2019-06-21T18:12:44,485][INFO ][c.a.e.s.StatsdService    ] [node_sd2] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,487][INFO ][c.a.e.s.StatsdService    ] [node_sm0] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,491][INFO ][o.e.t.TransportService   ] [integ_4] publish_address {127.0.0.1:45247}, bound_addresses {[::1]:40531}, {127.0.0.1:45247}
[2019-06-21T18:12:44,491][INFO ][c.a.e.s.StatsdService    ] [node_sd3] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,495][INFO ][c.a.e.s.StatsdService    ] [node_sd1] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,498][INFO ][c.a.e.s.StatsdService    ] [node_sd2] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,498][INFO ][c.a.e.s.StatsdService    ] [node_sm0] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,501][INFO ][o.e.t.TransportService   ] [integ_3] publish_address {127.0.0.1:37043}, bound_addresses {[::1]:41679}, {127.0.0.1:37043}
[2019-06-21T18:12:44,505][INFO ][c.a.e.s.StatsdService    ] [node_sd3] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,506][INFO ][c.a.e.s.StatsdService    ] [node_sd1] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,509][INFO ][c.a.e.s.StatsdService    ] [node_sd2] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,509][INFO ][c.a.e.s.StatsdService    ] [node_sm0] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,516][INFO ][c.a.e.s.StatsdService    ] [node_sd3] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,517][INFO ][c.a.e.s.StatsdService    ] [node_sd1] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,520][INFO ][c.a.e.s.StatsdService    ] [node_sd2] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,520][INFO ][c.a.e.s.StatsdService    ] [node_sm0] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,527][INFO ][c.a.e.s.StatsdService    ] [node_sd3] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,528][INFO ][c.a.e.s.StatsdService    ] [node_sd1] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,530][INFO ][c.a.e.s.StatsdService    ] [node_sd2] Cluster state not set yet. Looping...
[2019-06-21T18:12:44,619][INFO ][o.e.t.d.MockZenPing      ] [node_sd1] pinging using mock zen ping
[2019-06-21T18:12:44,625][INFO ][o.e.t.d.MockZenPing      ] [node_sm0] pinging using mock zen ping
[2019-06-21T18:12:44,626][INFO ][o.e.t.d.MockZenPing      ] [node_sd3] pinging using mock zen ping
[2019-06-21T18:12:44,625][INFO ][o.e.t.d.MockZenPing      ] [node_sd2] pinging using mock zen ping
[2019-06-21T18:12:44,813][INFO ][o.e.c.s.MasterService    ] [node_sm0] zen-disco-elected-as-master ([0] nodes joined), reason: new_master {node_sm0}{jDkU3_Y6TQq9nWYRfemB2w}{ltPA2pp1T3e7Hvimrss43w}{127.0.0.1}{127.0.0.1:46127}
[2019-06-21T18:12:44,851][INFO ][o.e.c.s.ClusterApplierService] [node_sm0] new_master {node_sm0}{jDkU3_Y6TQq9nWYRfemB2w}{ltPA2pp1T3e7Hvimrss43w}{127.0.0.1}{127.0.0.1:46127}, reason: apply cluster state (from master [master {node_sm0}{jDkU3_Y6TQq9nWYRfemB2w}{ltPA2pp1T3e7Hvimrss43w}{127.0.0.1}{127.0.0.1:46127} committed version [1] source [zen-disco-elected-as-master ([0] nodes joined)]])
[2019-06-21T18:12:44,950][INFO ][o.e.n.Node               ] [integ_1] started
[2019-06-21T18:12:45,025][INFO ][o.e.g.GatewayService     ] [node_sm0] recovered [0] indices into cluster_state
[2019-06-21T18:12:45,052][INFO ][o.e.c.s.MasterService    ] [node_sm0] zen-disco-node-join[{node_sd1}{Adp5TIalTH6GZrVGvUi5Ww}{txvJoGO7SYS9cUrjeBWLLQ}{127.0.0.1}{127.0.0.1:45319}, {node_sd3}{5wqF7w5hSXS16Fj3rfBSdg}{TsK19QuhTQmY3CWbf_Bj8Q}{127.0.0.1}{127.0.0.1:45247}, {node_sd2}{Uh7CwNsmRUezdtRGOKrfEg}{MjIDZuwFRM65Mwd1ETh9vQ}{127.0.0.1}{127.0.0.1:37043}], reason: added {{node_sd3}{5wqF7w5hSXS16Fj3rfBSdg}{TsK19QuhTQmY3CWbf_Bj8Q}{127.0.0.1}{127.0.0.1:45247},{node_sd1}{Adp5TIalTH6GZrVGvUi5Ww}{txvJoGO7SYS9cUrjeBWLLQ}{127.0.0.1}{127.0.0.1:45319},{node_sd2}{Uh7CwNsmRUezdtRGOKrfEg}{MjIDZuwFRM65Mwd1ETh9vQ}{127.0.0.1}{127.0.0.1:37043},}
[2019-06-21T18:12:45,111][INFO ][o.e.c.s.ClusterApplierService] [node_sd1] detected_master {node_sm0}{jDkU3_Y6TQq9nWYRfemB2w}{ltPA2pp1T3e7Hvimrss43w}{127.0.0.1}{127.0.0.1:46127}, added {{node_sm0}{jDkU3_Y6TQq9nWYRfemB2w}{ltPA2pp1T3e7Hvimrss43w}{127.0.0.1}{127.0.0.1:46127},{node_sd3}{5wqF7w5hSXS16Fj3rfBSdg}{TsK19QuhTQmY3CWbf_Bj8Q}{127.0.0.1}{127.0.0.1:45247},{node_sd2}{Uh7CwNsmRUezdtRGOKrfEg}{MjIDZuwFRM65Mwd1ETh9vQ}{127.0.0.1}{127.0.0.1:37043},}, reason: apply cluster state (from master [master {node_sm0}{jDkU3_Y6TQq9nWYRfemB2w}{ltPA2pp1T3e7Hvimrss43w}{127.0.0.1}{127.0.0.1:46127} committed version [3]])
[2019-06-21T18:12:45,112][INFO ][o.e.c.s.ClusterApplierService] [node_sd2] detected_master {node_sm0}{jDkU3_Y6TQq9nWYRfemB2w}{ltPA2pp1T3e7Hvimrss43w}{127.0.0.1}{127.0.0.1:46127}, added {{node_sm0}{jDkU3_Y6TQq9nWYRfemB2w}{ltPA2pp1T3e7Hvimrss43w}{127.0.0.1}{127.0.0.1:46127},{node_sd3}{5wqF7w5hSXS16Fj3rfBSdg}{TsK19QuhTQmY3CWbf_Bj8Q}{127.0.0.1}{127.0.0.1:45247},{node_sd1}{Adp5TIalTH6GZrVGvUi5Ww}{txvJoGO7SYS9cUrjeBWLLQ}{127.0.0.1}{127.0.0.1:45319},}, reason: apply cluster state (from master [master {node_sm0}{jDkU3_Y6TQq9nWYRfemB2w}{ltPA2pp1T3e7Hvimrss43w}{127.0.0.1}{127.0.0.1:46127} committed version [3]])
[2019-06-21T18:12:45,136][INFO ][o.e.c.s.ClusterApplierService] [node_sd3] detected_master {node_sm0}{jDkU3_Y6TQq9nWYRfemB2w}{ltPA2pp1T3e7Hvimrss43w}{127.0.0.1}{127.0.0.1:46127}, added {{node_sm0}{jDkU3_Y6TQq9nWYRfemB2w}{ltPA2pp1T3e7Hvimrss43w}{127.0.0.1}{127.0.0.1:46127},{node_sd1}{Adp5TIalTH6GZrVGvUi5Ww}{txvJoGO7SYS9cUrjeBWLLQ}{127.0.0.1}{127.0.0.1:45319},{node_sd2}{Uh7CwNsmRUezdtRGOKrfEg}{MjIDZuwFRM65Mwd1ETh9vQ}{127.0.0.1}{127.0.0.1:37043},}, reason: apply cluster state (from master [master {node_sm0}{jDkU3_Y6TQq9nWYRfemB2w}{ltPA2pp1T3e7Hvimrss43w}{127.0.0.1}{127.0.0.1:46127} committed version [3]])
[2019-06-21T18:12:45,261][INFO ][o.e.n.Node               ] [integ_3] started
[2019-06-21T18:12:45,262][INFO ][o.e.n.Node               ] [integ_4] started
[2019-06-21T18:12:45,268][INFO ][o.e.c.s.ClusterApplierService] [node_sm0] added {{node_sd3}{5wqF7w5hSXS16Fj3rfBSdg}{TsK19QuhTQmY3CWbf_Bj8Q}{127.0.0.1}{127.0.0.1:45247},{node_sd1}{Adp5TIalTH6GZrVGvUi5Ww}{txvJoGO7SYS9cUrjeBWLLQ}{127.0.0.1}{127.0.0.1:45319},{node_sd2}{Uh7CwNsmRUezdtRGOKrfEg}{MjIDZuwFRM65Mwd1ETh9vQ}{127.0.0.1}{127.0.0.1:37043},}, reason: apply cluster state (from master [master {node_sm0}{jDkU3_Y6TQq9nWYRfemB2w}{ltPA2pp1T3e7Hvimrss43w}{127.0.0.1}{127.0.0.1:46127} committed version [3] source [zen-disco-node-join[{node_sd1}{Adp5TIalTH6GZrVGvUi5Ww}{txvJoGO7SYS9cUrjeBWLLQ}{127.0.0.1}{127.0.0.1:45319}, {node_sd3}{5wqF7w5hSXS16Fj3rfBSdg}{TsK19QuhTQmY3CWbf_Bj8Q}{127.0.0.1}{127.0.0.1:45247}, {node_sd2}{Uh7CwNsmRUezdtRGOKrfEg}{MjIDZuwFRM65Mwd1ETh9vQ}{127.0.0.1}{127.0.0.1:37043}]]])
[2019-06-21T18:12:45,291][INFO ][o.e.n.Node               ] [integ_2] started
[2019-06-21T18:12:45,298][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] no modules loaded
[2019-06-21T18:12:45,299][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] loaded plugin [org.elasticsearch.transport.MockTcpTransportPlugin]
[2019-06-21T18:12:45,492][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] no modules loaded
[2019-06-21T18:12:45,496][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] loaded plugin [org.elasticsearch.transport.MockTcpTransportPlugin]
[2019-06-21T18:12:45,715][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] no modules loaded
[2019-06-21T18:12:45,722][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] loaded plugin [org.elasticsearch.transport.MockTcpTransportPlugin]
[2019-06-21T18:12:46,124][INFO ][o.e.c.m.MetaDataIndexTemplateService] [node_sm0] adding template [random_index_template] for index patterns [*]
[2019-06-21T18:12:46,192][INFO ][c.a.e.s.t.StatsdPluginIntegrationTest] [masterFailOverShouldWork] [StatsdPluginIntegrationTest#masterFailOverShouldWork]: all set up test
[2019-06-21T18:12:46,193][INFO ][c.a.e.s.t.StatsdPluginIntegrationTest] [masterFailOverShouldWork] Creating index dff53a
[2019-06-21T18:12:46,199][INFO ][c.a.e.s.t.StatsdPluginIntegrationTest] [masterFailOverShouldWork] using custom data_path for index: [fnALuFDWMB]
[2019-06-21T18:12:46,206][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] no modules loaded
[2019-06-21T18:12:46,210][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] loaded plugin [org.elasticsearch.transport.MockTcpTransportPlugin]
[2019-06-21T18:12:46,349][INFO ][o.e.c.m.MetaDataCreateIndexService] [node_sm0] [dff53a] creating index, cause [api], templates [random_index_template], shards [4]/[1], mappings []
[2019-06-21T18:12:47,963][INFO ][o.e.c.r.a.AllocationService] [node_sm0] Cluster health status changed from [YELLOW] to [GREEN] (reason: [shards started [[dff53a][0], [dff53a][1], [dff53a][3]] ...]).
[2019-06-21T18:12:48,141][INFO ][o.e.c.m.MetaDataMappingService] [node_sm0] [dff53a/_aRayPazQu-Nt53GtndcWQ] create_mapping [4f7e10]
[2019-06-21T18:12:48,971][INFO ][o.e.t.InternalTestCluster] [masterFailOverShouldWork] Closing master node [node_sm0] 
[2019-06-21T18:12:49,067][INFO ][o.e.n.Node               ] [masterFailOverShouldWork] stopping ...
[2019-06-21T18:12:49,106][INFO ][c.a.e.s.StatsdService    ] [masterFailOverShouldWork] StatsD reporter stopped
[2019-06-21T18:12:49,107][ERROR][c.a.e.s.StatsdService    ] [node_sm0] Exiting StatsdReporterThread
[2019-06-21T18:12:49,108][INFO ][o.e.n.Node               ] [masterFailOverShouldWork] stopped
[2019-06-21T18:12:49,108][INFO ][o.e.n.Node               ] [masterFailOverShouldWork] closing ...
[2019-06-21T18:12:49,109][INFO ][o.e.d.z.ZenDiscovery     ] [node_sd3] master_left [{node_sm0}{jDkU3_Y6TQq9nWYRfemB2w}{ltPA2pp1T3e7Hvimrss43w}{127.0.0.1}{127.0.0.1:46127}], reason [transport disconnected]
[2019-06-21T18:12:49,109][WARN ][o.e.d.z.ZenDiscovery     ] [node_sd3] master left (reason = transport disconnected), current nodes: nodes: 
   {node_sm0}{jDkU3_Y6TQq9nWYRfemB2w}{ltPA2pp1T3e7Hvimrss43w}{127.0.0.1}{127.0.0.1:46127}, master
   {node_sd3}{5wqF7w5hSXS16Fj3rfBSdg}{TsK19QuhTQmY3CWbf_Bj8Q}{127.0.0.1}{127.0.0.1:45247}, local
   {node_sd1}{Adp5TIalTH6GZrVGvUi5Ww}{txvJoGO7SYS9cUrjeBWLLQ}{127.0.0.1}{127.0.0.1:45319}
   {node_sd2}{Uh7CwNsmRUezdtRGOKrfEg}{MjIDZuwFRM65Mwd1ETh9vQ}{127.0.0.1}{127.0.0.1:37043}

[2019-06-21T18:12:49,110][INFO ][o.e.d.z.ZenDiscovery     ] [node_sd1] master_left [{node_sm0}{jDkU3_Y6TQq9nWYRfemB2w}{ltPA2pp1T3e7Hvimrss43w}{127.0.0.1}{127.0.0.1:46127}], reason [transport disconnected]
[2019-06-21T18:12:49,114][WARN ][o.e.d.z.ZenDiscovery     ] [node_sd1] master left (reason = transport disconnected), current nodes: nodes: 
   {node_sm0}{jDkU3_Y6TQq9nWYRfemB2w}{ltPA2pp1T3e7Hvimrss43w}{127.0.0.1}{127.0.0.1:46127}, master
   {node_sd3}{5wqF7w5hSXS16Fj3rfBSdg}{TsK19QuhTQmY3CWbf_Bj8Q}{127.0.0.1}{127.0.0.1:45247}
   {node_sd1}{Adp5TIalTH6GZrVGvUi5Ww}{txvJoGO7SYS9cUrjeBWLLQ}{127.0.0.1}{127.0.0.1:45319}, local
   {node_sd2}{Uh7CwNsmRUezdtRGOKrfEg}{MjIDZuwFRM65Mwd1ETh9vQ}{127.0.0.1}{127.0.0.1:37043}

[2019-06-21T18:12:49,110][INFO ][o.e.d.z.ZenDiscovery     ] [node_sd2] master_left [{node_sm0}{jDkU3_Y6TQq9nWYRfemB2w}{ltPA2pp1T3e7Hvimrss43w}{127.0.0.1}{127.0.0.1:46127}], reason [transport disconnected]
[2019-06-21T18:12:49,117][WARN ][o.e.d.z.ZenDiscovery     ] [node_sd2] master left (reason = transport disconnected), current nodes: nodes: 
   {node_sm0}{jDkU3_Y6TQq9nWYRfemB2w}{ltPA2pp1T3e7Hvimrss43w}{127.0.0.1}{127.0.0.1:46127}, master
   {node_sd3}{5wqF7w5hSXS16Fj3rfBSdg}{TsK19QuhTQmY3CWbf_Bj8Q}{127.0.0.1}{127.0.0.1:45247}
   {node_sd1}{Adp5TIalTH6GZrVGvUi5Ww}{txvJoGO7SYS9cUrjeBWLLQ}{127.0.0.1}{127.0.0.1:45319}
   {node_sd2}{Uh7CwNsmRUezdtRGOKrfEg}{MjIDZuwFRM65Mwd1ETh9vQ}{127.0.0.1}{127.0.0.1:37043}, local

[2019-06-21T18:12:49,120][INFO ][o.e.t.d.MockZenPing      ] [node_sd2] pinging using mock zen ping
[2019-06-21T18:12:49,128][INFO ][o.e.t.d.MockZenPing      ] [node_sd1] pinging using mock zen ping
[2019-06-21T18:12:49,130][INFO ][o.e.t.d.MockZenPing      ] [node_sd3] pinging using mock zen ping
[2019-06-21T18:12:49,162][INFO ][o.e.n.Node               ] [masterFailOverShouldWork] closed
[2019-06-21T18:12:49,150][WARN ][o.e.c.NodeConnectionsService] [node_sd3] failed to connect to node {node_sm0}{jDkU3_Y6TQq9nWYRfemB2w}{ltPA2pp1T3e7Hvimrss43w}{127.0.0.1}{127.0.0.1:46127} (tried [1] times)
org.elasticsearch.transport.ConnectTransportException: [node_sm0][127.0.0.1:46127] connect_exception
        at org.elasticsearch.transport.TcpTransport$ChannelsConnectedListener.onFailure(TcpTransport.java:1309) ~[elasticsearch-6.8.1.jar:6.8.1]
        at org.elasticsearch.action.ActionListener.lambda$toBiConsumer$2(ActionListener.java:100) ~[elasticsearch-6.8.1.jar:6.8.1]
        at org.elasticsearch.common.concurrent.CompletableContext.lambda$addListener$0(CompletableContext.java:42) ~[elasticsearch-core-6.8.1.jar:6.8.1]
        at java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:760) ~[?:1.8.0_212]
        at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:736) ~[?:1.8.0_212]
        at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:474) ~[?:1.8.0_212]
        at java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:1977) ~[?:1.8.0_212]
        at org.elasticsearch.common.concurrent.CompletableContext.completeExceptionally(CompletableContext.java:57) ~[elasticsearch-core-6.8.1.jar:6.8.1]
        at org.elasticsearch.transport.MockTcpTransport.lambda$initiateChannel$0(MockTcpTransport.java:195) ~[framework-6.8.1.jar:6.8.1]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) ~[?:1.8.0_212]
        at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~[?:1.8.0_212]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_212]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_212]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_212]
Caused by: java.net.ConnectException: Connection refused (Connection refused)
        at java.net.PlainSocketImpl.socketConnect(Native Method) ~[?:1.8.0_212]
        at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:350) ~[?:1.8.0_212]
        at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:206) ~[?:1.8.0_212]
        at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:188) ~[?:1.8.0_212]
        at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392) ~[?:1.8.0_212]
        at java.net.Socket.connect(Socket.java:589) ~[?:1.8.0_212]
        at org.elasticsearch.mocksocket.MockSocket.access$101(MockSocket.java:32) ~[mocksocket-1.2.jar:?]
        at org.elasticsearch.mocksocket.MockSocket.lambda$connect$0(MockSocket.java:66) ~[mocksocket-1.2.jar:?]
        at java.security.AccessController.doPrivileged(Native Method) ~[?:1.8.0_212]
        at org.elasticsearch.mocksocket.MockSocket.connect(MockSocket.java:65) ~[mocksocket-1.2.jar:?]
        at org.elasticsearch.mocksocket.MockSocket.connect(MockSocket.java:59) ~[mocksocket-1.2.jar:?]
        at org.elasticsearch.transport.MockTcpTransport.lambda$initiateChannel$0(MockTcpTransport.java:190) ~[framework-6.8.1.jar:6.8.1]
        ... 5 more
[2019-06-21T18:12:49,183][INFO ][o.e.e.NodeEnvironment    ] [masterFailOverShouldWork] using [1] data paths, mounts [[/ (/dev/sda1)]], net usable_space [7.6gb], net total_space [29.3gb], types [ext4]
[2019-06-21T18:12:49,149][WARN ][o.e.c.NodeConnectionsService] [node_sd1] failed to connect to node {node_sm0}{jDkU3_Y6TQq9nWYRfemB2w}{ltPA2pp1T3e7Hvimrss43w}{127.0.0.1}{127.0.0.1:46127} (tried [1] times)
org.elasticsearch.transport.ConnectTransportException: [node_sm0][127.0.0.1:46127] connect_exception
        at org.elasticsearch.transport.TcpTransport$ChannelsConnectedListener.onFailure(TcpTransport.java:1309) ~[elasticsearch-6.8.1.jar:6.8.1]
        at org.elasticsearch.action.ActionListener.lambda$toBiConsumer$2(ActionListener.java:100) ~[elasticsearch-6.8.1.jar:6.8.1]
        at org.elasticsearch.common.concurrent.CompletableContext.lambda$addListener$0(CompletableContext.java:42) ~[elasticsearch-core-6.8.1.jar:6.8.1]
        at java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:760) ~[?:1.8.0_212]
        at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:736) ~[?:1.8.0_212]
        at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:474) ~[?:1.8.0_212]
        at java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:1977) ~[?:1.8.0_212]
        at org.elasticsearch.common.concurrent.CompletableContext.completeExceptionally(CompletableContext.java:57) ~[elasticsearch-core-6.8.1.jar:6.8.1]
        at org.elasticsearch.transport.MockTcpTransport.lambda$initiateChannel$0(MockTcpTransport.java:195) ~[framework-6.8.1.jar:6.8.1]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) ~[?:1.8.0_212]
        at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~[?:1.8.0_212]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_212]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_212]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_212]
Caused by: java.net.ConnectException: Connection refused (Connection refused)
        at java.net.PlainSocketImpl.socketConnect(Native Method) ~[?:1.8.0_212]
        at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:350) ~[?:1.8.0_212]
        at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:206) ~[?:1.8.0_212]
        at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:188) ~[?:1.8.0_212]
        at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392) ~[?:1.8.0_212]
        at java.net.Socket.connect(Socket.java:589) ~[?:1.8.0_212]
        at org.elasticsearch.mocksocket.MockSocket.access$101(MockSocket.java:32) ~[mocksocket-1.2.jar:?]
        at org.elasticsearch.mocksocket.MockSocket.lambda$connect$0(MockSocket.java:66) ~[mocksocket-1.2.jar:?]
        at java.security.AccessController.doPrivileged(Native Method) ~[?:1.8.0_212]
        at org.elasticsearch.mocksocket.MockSocket.connect(MockSocket.java:65) ~[mocksocket-1.2.jar:?]
        at org.elasticsearch.mocksocket.MockSocket.connect(MockSocket.java:59) ~[mocksocket-1.2.jar:?]
        at org.elasticsearch.transport.MockTcpTransport.lambda$initiateChannel$0(MockTcpTransport.java:190) ~[framework-6.8.1.jar:6.8.1]
        ... 5 more
[2019-06-21T18:12:49,151][WARN ][o.e.c.NodeConnectionsService] [node_sd2] failed to connect to node {node_sm0}{jDkU3_Y6TQq9nWYRfemB2w}{ltPA2pp1T3e7Hvimrss43w}{127.0.0.1}{127.0.0.1:46127} (tried [1] times)
org.elasticsearch.transport.ConnectTransportException: [node_sm0][127.0.0.1:46127] connect_exception
        at org.elasticsearch.transport.TcpTransport$ChannelsConnectedListener.onFailure(TcpTransport.java:1309) ~[elasticsearch-6.8.1.jar:6.8.1]
        at org.elasticsearch.action.ActionListener.lambda$toBiConsumer$2(ActionListener.java:100) ~[elasticsearch-6.8.1.jar:6.8.1]
        at org.elasticsearch.common.concurrent.CompletableContext.lambda$addListener$0(CompletableContext.java:42) ~[elasticsearch-core-6.8.1.jar:6.8.1]
        at java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:760) ~[?:1.8.0_212]
        at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:736) ~[?:1.8.0_212]
        at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:474) ~[?:1.8.0_212]
        at java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:1977) ~[?:1.8.0_212]
        at org.elasticsearch.common.concurrent.CompletableContext.completeExceptionally(CompletableContext.java:57) ~[elasticsearch-core-6.8.1.jar:6.8.1]
        at org.elasticsearch.transport.MockTcpTransport.lambda$initiateChannel$0(MockTcpTransport.java:195) ~[framework-6.8.1.jar:6.8.1]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) ~[?:1.8.0_212]
        at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~[?:1.8.0_212]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_212]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_212]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_212]
Caused by: java.net.ConnectException: Connection refused (Connection refused)
        at java.net.PlainSocketImpl.socketConnect(Native Method) ~[?:1.8.0_212]
        at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:350) ~[?:1.8.0_212]
        at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:206) ~[?:1.8.0_212]
        at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:188) ~[?:1.8.0_212]
        at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392) ~[?:1.8.0_212]
        at java.net.Socket.connect(Socket.java:589) ~[?:1.8.0_212]
        at org.elasticsearch.mocksocket.MockSocket.access$101(MockSocket.java:32) ~[mocksocket-1.2.jar:?]
        at org.elasticsearch.mocksocket.MockSocket.lambda$connect$0(MockSocket.java:66) ~[mocksocket-1.2.jar:?]
        at java.security.AccessController.doPrivileged(Native Method) ~[?:1.8.0_212]
        at org.elasticsearch.mocksocket.MockSocket.connect(MockSocket.java:65) ~[mocksocket-1.2.jar:?]
        at org.elasticsearch.mocksocket.MockSocket.connect(MockSocket.java:59) ~[mocksocket-1.2.jar:?]
        at org.elasticsearch.transport.MockTcpTransport.lambda$initiateChannel$0(MockTcpTransport.java:190) ~[framework-6.8.1.jar:6.8.1]
        ... 5 more
[2019-06-21T18:12:49,240][INFO ][o.e.e.NodeEnvironment    ] [masterFailOverShouldWork] heap size [1.2gb], compressed ordinary object pointers [true]
[2019-06-21T18:12:49,256][INFO ][o.e.n.Node               ] [masterFailOverShouldWork] node name [node_s4], node ID [jDkU3_Y6TQq9nWYRfemB2w]
[2019-06-21T18:12:49,258][INFO ][o.e.n.Node               ] [masterFailOverShouldWork] version[6.8.1], pid[14254], build[unknown/unknown/1fad4e1/2019-06-18T13:16:52.517138Z], OS[Linux/4.18.0-20-generic/amd64], JVM[Oracle Corporation/OpenJDK 64-Bit Server VM/1.8.0_212/25.212-b03]
[2019-06-21T18:12:49,263][INFO ][o.e.n.Node               ] [masterFailOverShouldWork] JVM arguments []
[2019-06-21T18:12:49,264][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] no modules loaded
[2019-06-21T18:12:49,265][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] loaded plugin [com.automattic.elasticsearch.plugin.StatsdPlugin]
[2019-06-21T18:12:49,265][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] loaded plugin [org.elasticsearch.test.ESIntegTestCase$AssertActionNamePlugin]
[2019-06-21T18:12:49,266][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] loaded plugin [org.elasticsearch.test.ESIntegTestCase$TestSeedPlugin]
[2019-06-21T18:12:49,266][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] loaded plugin [org.elasticsearch.test.discovery.TestZenDiscovery$TestPlugin]
[2019-06-21T18:12:49,267][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] loaded plugin [org.elasticsearch.transport.MockTcpTransportPlugin]
[2019-06-21T18:12:49,408][INFO ][o.e.d.DiscoveryModule    ] [masterFailOverShouldWork] using discovery type [test-zen] and host providers [settings, file]
[2019-06-21T18:12:49,516][INFO ][o.e.n.Node               ] [masterFailOverShouldWork] initialized
[2019-06-21T18:12:49,521][INFO ][o.e.n.Node               ] [integ_5] starting ...
[2019-06-21T18:12:49,540][INFO ][c.a.e.s.StatsdService    ] [integ_5] StatsD reporting triggered every [1s] to host [localhost:12345] with metric prefix [myhost4]
[2019-06-21T18:12:49,565][INFO ][c.a.e.s.StatsdService    ] [node_s4] Cluster state not set yet. Looping...
[2019-06-21T18:12:49,567][INFO ][o.e.t.TransportService   ] [integ_5] publish_address {127.0.0.1:38179}, bound_addresses {[::1]:42971}, {127.0.0.1:38179}
[2019-06-21T18:12:49,609][INFO ][o.e.t.d.MockZenPing      ] [node_s4] pinging using mock zen ping
[2019-06-21T18:12:49,669][INFO ][o.e.c.s.MasterService    ] [node_s4] zen-disco-elected-as-master ([0] nodes joined), reason: new_master {node_s4}{jDkU3_Y6TQq9nWYRfemB2w}{d3mjsm6ZT6S53HfKdhMt5A}{127.0.0.1}{127.0.0.1:38179}
[2019-06-21T18:12:49,671][INFO ][o.e.c.s.ClusterApplierService] [node_s4] new_master {node_s4}{jDkU3_Y6TQq9nWYRfemB2w}{d3mjsm6ZT6S53HfKdhMt5A}{127.0.0.1}{127.0.0.1:38179}, reason: apply cluster state (from master [master {node_s4}{jDkU3_Y6TQq9nWYRfemB2w}{d3mjsm6ZT6S53HfKdhMt5A}{127.0.0.1}{127.0.0.1:38179} committed version [1] source [zen-disco-elected-as-master ([0] nodes joined)]])
[2019-06-21T18:12:49,677][INFO ][o.e.n.Node               ] [integ_5] started
[2019-06-21T18:12:49,763][INFO ][o.e.c.s.MasterService    ] [node_s4] zen-disco-node-join[{node_sd3}{5wqF7w5hSXS16Fj3rfBSdg}{TsK19QuhTQmY3CWbf_Bj8Q}{127.0.0.1}{127.0.0.1:45247}], reason: added {{node_sd3}{5wqF7w5hSXS16Fj3rfBSdg}{TsK19QuhTQmY3CWbf_Bj8Q}{127.0.0.1}{127.0.0.1:45247},}
[2019-06-21T18:12:49,778][INFO ][o.e.c.s.ClusterApplierService] [node_sd3] master {new {node_s4}{jDkU3_Y6TQq9nWYRfemB2w}{d3mjsm6ZT6S53HfKdhMt5A}{127.0.0.1}{127.0.0.1:38179}}, removed {{node_sm0}{jDkU3_Y6TQq9nWYRfemB2w}{ltPA2pp1T3e7Hvimrss43w}{127.0.0.1}{127.0.0.1:46127},{node_sd1}{Adp5TIalTH6GZrVGvUi5Ww}{txvJoGO7SYS9cUrjeBWLLQ}{127.0.0.1}{127.0.0.1:45319},{node_sd2}{Uh7CwNsmRUezdtRGOKrfEg}{MjIDZuwFRM65Mwd1ETh9vQ}{127.0.0.1}{127.0.0.1:37043},}, added {{node_s4}{jDkU3_Y6TQq9nWYRfemB2w}{d3mjsm6ZT6S53HfKdhMt5A}{127.0.0.1}{127.0.0.1:38179},}, reason: apply cluster state (from master [master {node_s4}{jDkU3_Y6TQq9nWYRfemB2w}{d3mjsm6ZT6S53HfKdhMt5A}{127.0.0.1}{127.0.0.1:38179} committed version [2]])
[2019-06-21T18:12:49,843][INFO ][o.e.c.s.ClusterApplierService] [node_s4] added {{node_sd3}{5wqF7w5hSXS16Fj3rfBSdg}{TsK19QuhTQmY3CWbf_Bj8Q}{127.0.0.1}{127.0.0.1:45247},}, reason: apply cluster state (from master [master {node_s4}{jDkU3_Y6TQq9nWYRfemB2w}{d3mjsm6ZT6S53HfKdhMt5A}{127.0.0.1}{127.0.0.1:38179} committed version [2] source [zen-disco-node-join[{node_sd3}{5wqF7w5hSXS16Fj3rfBSdg}{TsK19QuhTQmY3CWbf_Bj8Q}{127.0.0.1}{127.0.0.1:45247}]]])
[2019-06-21T18:12:49,845][INFO ][o.e.c.s.MasterService    ] [node_s4] zen-disco-node-join[{node_sd2}{Uh7CwNsmRUezdtRGOKrfEg}{MjIDZuwFRM65Mwd1ETh9vQ}{127.0.0.1}{127.0.0.1:37043}, {node_sd1}{Adp5TIalTH6GZrVGvUi5Ww}{txvJoGO7SYS9cUrjeBWLLQ}{127.0.0.1}{127.0.0.1:45319}], reason: added {{node_sd2}{Uh7CwNsmRUezdtRGOKrfEg}{MjIDZuwFRM65Mwd1ETh9vQ}{127.0.0.1}{127.0.0.1:37043},{node_sd1}{Adp5TIalTH6GZrVGvUi5Ww}{txvJoGO7SYS9cUrjeBWLLQ}{127.0.0.1}{127.0.0.1:45319},}
[2019-06-21T18:12:49,855][INFO ][o.e.c.s.ClusterApplierService] [node_sd2] master {new {node_s4}{jDkU3_Y6TQq9nWYRfemB2w}{d3mjsm6ZT6S53HfKdhMt5A}{127.0.0.1}{127.0.0.1:38179}}, removed {{node_sm0}{jDkU3_Y6TQq9nWYRfemB2w}{ltPA2pp1T3e7Hvimrss43w}{127.0.0.1}{127.0.0.1:46127},}, added {{node_s4}{jDkU3_Y6TQq9nWYRfemB2w}{d3mjsm6ZT6S53HfKdhMt5A}{127.0.0.1}{127.0.0.1:38179},}, reason: apply cluster state (from master [master {node_s4}{jDkU3_Y6TQq9nWYRfemB2w}{d3mjsm6ZT6S53HfKdhMt5A}{127.0.0.1}{127.0.0.1:38179} committed version [3]])
[2019-06-21T18:12:49,857][INFO ][o.e.c.s.ClusterApplierService] [node_sd3] added {{node_sd2}{Uh7CwNsmRUezdtRGOKrfEg}{MjIDZuwFRM65Mwd1ETh9vQ}{127.0.0.1}{127.0.0.1:37043},{node_sd1}{Adp5TIalTH6GZrVGvUi5Ww}{txvJoGO7SYS9cUrjeBWLLQ}{127.0.0.1}{127.0.0.1:45319},}, reason: apply cluster state (from master [master {node_s4}{jDkU3_Y6TQq9nWYRfemB2w}{d3mjsm6ZT6S53HfKdhMt5A}{127.0.0.1}{127.0.0.1:38179} committed version [3]])
[2019-06-21T18:12:49,859][INFO ][o.e.c.s.ClusterApplierService] [node_sd1] master {new {node_s4}{jDkU3_Y6TQq9nWYRfemB2w}{d3mjsm6ZT6S53HfKdhMt5A}{127.0.0.1}{127.0.0.1:38179}}, removed {{node_sm0}{jDkU3_Y6TQq9nWYRfemB2w}{ltPA2pp1T3e7Hvimrss43w}{127.0.0.1}{127.0.0.1:46127},}, added {{node_s4}{jDkU3_Y6TQq9nWYRfemB2w}{d3mjsm6ZT6S53HfKdhMt5A}{127.0.0.1}{127.0.0.1:38179},}, reason: apply cluster state (from master [master {node_s4}{jDkU3_Y6TQq9nWYRfemB2w}{d3mjsm6ZT6S53HfKdhMt5A}{127.0.0.1}{127.0.0.1:38179} committed version [3]])
[2019-06-21T18:12:49,928][INFO ][o.e.c.s.ClusterApplierService] [node_s4] added {{node_sd2}{Uh7CwNsmRUezdtRGOKrfEg}{MjIDZuwFRM65Mwd1ETh9vQ}{127.0.0.1}{127.0.0.1:37043},{node_sd1}{Adp5TIalTH6GZrVGvUi5Ww}{txvJoGO7SYS9cUrjeBWLLQ}{127.0.0.1}{127.0.0.1:45319},}, reason: apply cluster state (from master [master {node_s4}{jDkU3_Y6TQq9nWYRfemB2w}{d3mjsm6ZT6S53HfKdhMt5A}{127.0.0.1}{127.0.0.1:38179} committed version [3] source [zen-disco-node-join[{node_sd2}{Uh7CwNsmRUezdtRGOKrfEg}{MjIDZuwFRM65Mwd1ETh9vQ}{127.0.0.1}{127.0.0.1:37043}, {node_sd1}{Adp5TIalTH6GZrVGvUi5Ww}{txvJoGO7SYS9cUrjeBWLLQ}{127.0.0.1}{127.0.0.1:45319}]]])
[2019-06-21T18:12:50,073][INFO ][o.e.g.GatewayService     ] [node_s4] recovered [1] indices into cluster_state
[2019-06-21T18:12:50,473][INFO ][o.e.c.r.a.AllocationService] [node_s4] Cluster health status changed from [RED] to [YELLOW] (reason: [shards started [[dff53a][2]] ...]).
[2019-06-21T18:12:51,001][INFO ][o.e.c.r.a.AllocationService] [node_s4] Cluster health status changed from [YELLOW] to [GREEN] (reason: [shards started [[dff53a][3]] ...]).
stopped master
[2019-06-21T18:12:53,951][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] no modules loaded
[2019-06-21T18:12:53,951][INFO ][o.e.p.PluginsService     ] [masterFailOverShouldWork] loaded plugin [org.elasticsearch.transport.MockTcpTransportPlugin]
[2019-06-21T18:12:58,045][INFO ][c.a.e.s.t.StatsdPluginIntegrationTest] [masterFailOverShouldWork] [StatsdPluginIntegrationTest#masterFailOverShouldWork]: cleaning up after test
[2019-06-21T18:12:58,264][INFO ][o.e.c.m.MetaDataDeleteIndexService] [node_s4] [dff53a/_aRayPazQu-Nt53GtndcWQ] deleting index
[2019-06-21T18:12:58,411][INFO ][o.e.c.m.MetaDataIndexTemplateService] [node_s4] removing template [random_index_template]
[2019-06-21T18:12:58,442][INFO ][c.a.e.s.t.StatsdPluginIntegrationTest] [masterFailOverShouldWork] [StatsdPluginIntegrationTest#masterFailOverShouldWork]: cleaned up after test
[2019-06-21T18:12:58,448][INFO ][c.a.e.s.t.StatsdPluginIntegrationTest] [masterFailOverShouldWork] after test
[2019-06-21T18:12:58,662][INFO ][c.a.e.s.t.StatsdPluginIntegrationTest] [testThatIndexingResultsInMonitoring] before test
[2019-06-21T18:12:58,662][INFO ][c.a.e.s.t.StatsdPluginIntegrationTest] [testThatIndexingResultsInMonitoring] [StatsdPluginIntegrationTest#testThatIndexingResultsInMonitoring]: setting up test
[2019-06-21T18:12:58,701][INFO ][o.e.n.Node               ] [testThatIndexingResultsInMonitoring] stopping ...
[2019-06-21T18:12:58,712][INFO ][o.e.d.z.ZenDiscovery     ] [node_sd2] master_left [{node_s4}{jDkU3_Y6TQq9nWYRfemB2w}{d3mjsm6ZT6S53HfKdhMt5A}{127.0.0.1}{127.0.0.1:38179}], reason [transport disconnected]
[2019-06-21T18:12:58,713][WARN ][o.e.d.z.ZenDiscovery     ] [node_sd2] master left (reason = transport disconnected), current nodes: nodes: 
   {node_s4}{jDkU3_Y6TQq9nWYRfemB2w}{d3mjsm6ZT6S53HfKdhMt5A}{127.0.0.1}{127.0.0.1:38179}, master
   {node_sd3}{5wqF7w5hSXS16Fj3rfBSdg}{TsK19QuhTQmY3CWbf_Bj8Q}{127.0.0.1}{127.0.0.1:45247}
   {node_sd2}{Uh7CwNsmRUezdtRGOKrfEg}{MjIDZuwFRM65Mwd1ETh9vQ}{127.0.0.1}{127.0.0.1:37043}, local
   {node_sd1}{Adp5TIalTH6GZrVGvUi5Ww}{txvJoGO7SYS9cUrjeBWLLQ}{127.0.0.1}{127.0.0.1:45319}

[2019-06-21T18:12:58,717][INFO ][c.a.e.s.StatsdService    ] [testThatIndexingResultsInMonitoring] StatsD reporter stopped
[2019-06-21T18:12:58,715][INFO ][o.e.d.z.ZenDiscovery     ] [node_sd1] master_left [{node_s4}{jDkU3_Y6TQq9nWYRfemB2w}{d3mjsm6ZT6S53HfKdhMt5A}{127.0.0.1}{127.0.0.1:38179}], reason [transport disconnected]
[2019-06-21T18:12:58,721][WARN ][o.e.d.z.ZenDiscovery     ] [node_sd1] master left (reason = transport disconnected), current nodes: nodes: 
   {node_s4}{jDkU3_Y6TQq9nWYRfemB2w}{d3mjsm6ZT6S53HfKdhMt5A}{127.0.0.1}{127.0.0.1:38179}, master
   {node_sd3}{5wqF7w5hSXS16Fj3rfBSdg}{TsK19QuhTQmY3CWbf_Bj8Q}{127.0.0.1}{127.0.0.1:45247}
   {node_sd2}{Uh7CwNsmRUezdtRGOKrfEg}{MjIDZuwFRM65Mwd1ETh9vQ}{127.0.0.1}{127.0.0.1:37043}
   {node_sd1}{Adp5TIalTH6GZrVGvUi5Ww}{txvJoGO7SYS9cUrjeBWLLQ}{127.0.0.1}{127.0.0.1:45319}, local

[2019-06-21T18:12:58,714][INFO ][o.e.d.z.ZenDiscovery     ] [node_sd3] master_left [{node_s4}{jDkU3_Y6TQq9nWYRfemB2w}{d3mjsm6ZT6S53HfKdhMt5A}{127.0.0.1}{127.0.0.1:38179}], reason [transport disconnected]
[2019-06-21T18:12:58,722][INFO ][o.e.t.d.MockZenPing      ] [node_sd1] pinging using mock zen ping
[2019-06-21T18:12:58,718][INFO ][o.e.t.d.MockZenPing      ] [node_sd2] pinging using mock zen ping
[2019-06-21T18:12:58,717][ERROR][c.a.e.s.StatsdService    ] [node_s4] Exiting StatsdReporterThread
[2019-06-21T18:12:58,723][WARN ][o.e.d.z.ZenDiscovery     ] [node_sd3] master left (reason = transport disconnected), current nodes: nodes: 
   {node_s4}{jDkU3_Y6TQq9nWYRfemB2w}{d3mjsm6ZT6S53HfKdhMt5A}{127.0.0.1}{127.0.0.1:38179}, master
   {node_sd3}{5wqF7w5hSXS16Fj3rfBSdg}{TsK19QuhTQmY3CWbf_Bj8Q}{127.0.0.1}{127.0.0.1:45247}, local
   {node_sd2}{Uh7CwNsmRUezdtRGOKrfEg}{MjIDZuwFRM65Mwd1ETh9vQ}{127.0.0.1}{127.0.0.1:37043}
   {node_sd1}{Adp5TIalTH6GZrVGvUi5Ww}{txvJoGO7SYS9cUrjeBWLLQ}{127.0.0.1}{127.0.0.1:45319}

[2019-06-21T18:12:58,725][INFO ][o.e.t.d.MockZenPing      ] [node_sd3] pinging using mock zen ping
[2019-06-21T18:12:58,739][INFO ][o.e.n.Node               ] [testThatIndexingResultsInMonitoring] stopped
[2019-06-21T18:12:58,740][INFO ][o.e.n.Node               ] [testThatIndexingResultsInMonitoring] closing ...
[2019-06-21T18:12:58,746][WARN ][o.e.c.NodeConnectionsService] [node_sd2] failed to connect to node {node_s4}{jDkU3_Y6TQq9nWYRfemB2w}{d3mjsm6ZT6S53HfKdhMt5A}{127.0.0.1}{127.0.0.1:38179} (tried [1] times)
org.elasticsearch.transport.ConnectTransportException: [node_s4][127.0.0.1:38179] connect_exception
        at org.elasticsearch.transport.TcpTransport$ChannelsConnectedListener.onFailure(TcpTransport.java:1309) ~[elasticsearch-6.8.1.jar:6.8.1]
        at org.elasticsearch.action.ActionListener.lambda$toBiConsumer$2(ActionListener.java:100) ~[elasticsearch-6.8.1.jar:6.8.1]
        at org.elasticsearch.common.concurrent.CompletableContext.lambda$addListener$0(CompletableContext.java:42) ~[elasticsearch-core-6.8.1.jar:6.8.1]
        at java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:760) ~[?:1.8.0_212]
        at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:736) ~[?:1.8.0_212]
        at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:474) ~[?:1.8.0_212]
        at java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:1977) ~[?:1.8.0_212]
        at org.elasticsearch.common.concurrent.CompletableContext.completeExceptionally(CompletableContext.java:57) ~[elasticsearch-core-6.8.1.jar:6.8.1]
        at org.elasticsearch.transport.MockTcpTransport.lambda$initiateChannel$0(MockTcpTransport.java:195) ~[framework-6.8.1.jar:6.8.1]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) ~[?:1.8.0_212]
        at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~[?:1.8.0_212]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_212]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_212]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_212]
Caused by: java.net.ConnectException: Connection refused (Connection refused)
        at java.net.PlainSocketImpl.socketConnect(Native Method) ~[?:1.8.0_212]
        at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:350) ~[?:1.8.0_212]
        at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:206) ~[?:1.8.0_212]
        at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:188) ~[?:1.8.0_212]
        at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392) ~[?:1.8.0_212]
        at java.net.Socket.connect(Socket.java:589) ~[?:1.8.0_212]
        at org.elasticsearch.mocksocket.MockSocket.access$101(MockSocket.java:32) ~[mocksocket-1.2.jar:?]
        at org.elasticsearch.mocksocket.MockSocket.lambda$connect$0(MockSocket.java:66) ~[mocksocket-1.2.jar:?]
        at java.security.AccessController.doPrivileged(Native Method) ~[?:1.8.0_212]
        at org.elasticsearch.mocksocket.MockSocket.connect(MockSocket.java:65) ~[mocksocket-1.2.jar:?]
        at org.elasticsearch.mocksocket.MockSocket.connect(MockSocket.java:59) ~[mocksocket-1.2.jar:?]
        at org.elasticsearch.transport.MockTcpTransport.lambda$initiateChannel$0(MockTcpTransport.java:190) ~[framework-6.8.1.jar:6.8.1]
        ... 5 more
[2019-06-21T18:12:58,746][WARN ][o.e.c.NodeConnectionsService] [node_sd1] failed to connect to node {node_s4}{jDkU3_Y6TQq9nWYRfemB2w}{d3mjsm6ZT6S53HfKdhMt5A}{127.0.0.1}{127.0.0.1:38179} (tried [1] times)
org.elasticsearch.transport.ConnectTransportException: [node_s4][127.0.0.1:38179] connect_exception
        at org.elasticsearch.transport.TcpTransport$ChannelsConnectedListener.onFailure(TcpTransport.java:1309) ~[elasticsearch-6.8.1.jar:6.8.1]
        at org.elasticsearch.action.ActionListener.lambda$toBiConsumer$2(ActionListener.java:100) ~[elasticsearch-6.8.1.jar:6.8.1]
        at org.elasticsearch.common.concurrent.CompletableContext.lambda$addListener$0(CompletableContext.java:42) ~[elasticsearch-core-6.8.1.jar:6.8.1]
        at java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:760) ~[?:1.8.0_212]
        at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:736) ~[?:1.8.0_212]
        at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:474) ~[?:1.8.0_212]
        at java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:1977) ~[?:1.8.0_212]
        at org.elasticsearch.common.concurrent.CompletableContext.completeExceptionally(CompletableContext.java:57) ~[elasticsearch-core-6.8.1.jar:6.8.1]
        at org.elasticsearch.transport.MockTcpTransport.lambda$initiateChannel$0(MockTcpTransport.java:195) ~[framework-6.8.1.jar:6.8.1]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) ~[?:1.8.0_212]
        at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~[?:1.8.0_212]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_212]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_212]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_212]
Caused by: java.net.ConnectException: Connection refused (Connection refused)
        at java.net.PlainSocketImpl.socketConnect(Native Method) ~[?:1.8.0_212]
        at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:350) ~[?:1.8.0_212]
        at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:206) ~[?:1.8.0_212]
        at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:188) ~[?:1.8.0_212]
        at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392) ~[?:1.8.0_212]
        at java.net.Socket.connect(Socket.java:589) ~[?:1.8.0_212]
        at org.elasticsearch.mocksocket.MockSocket.access$101(MockSocket.java:32) ~[mocksocket-1.2.jar:?]
        at org.elasticsearch.mocksocket.MockSocket.lambda$connect$0(MockSocket.java:66) ~[mocksocket-1.2.jar:?]
        at java.security.AccessController.doPrivileged(Native Method) ~[?:1.8.0_212]
        at org.elasticsearch.mocksocket.MockSocket.connect(MockSocket.java:65) ~[mocksocket-1.2.jar:?]
        at org.elasticsearch.mocksocket.MockSocket.connect(MockSocket.java:59) ~[mocksocket-1.2.jar:?]
        at org.elasticsearch.transport.MockTcpTransport.lambda$initiateChannel$0(MockTcpTransport.java:190) ~[framework-6.8.1.jar:6.8.1]
        ... 5 more
[2019-06-21T18:12:58,758][INFO ][o.e.n.Node               ] [testThatIndexingResultsInMonitoring] closed
[2019-06-21T18:12:58,841][INFO ][o.e.t.InternalTestCluster] [testThatIndexingResultsInMonitoring] Successfully wiped data directory for node location: /tmp/com.automattic.elasticsearch.statsd.test.StatsdPluginIntegrationTest_55E1FD22EA2D932D-001/tempDir-002/data/nodes/0
[2019-06-21T18:12:58,737][WARN ][o.e.c.NodeConnectionsService] [node_sd3] failed to connect to node {node_s4}{jDkU3_Y6TQq9nWYRfemB2w}{d3mjsm6ZT6S53HfKdhMt5A}{127.0.0.1}{127.0.0.1:38179} (tried [1] times)
org.elasticsearch.transport.ConnectTransportException: [node_s4][127.0.0.1:38179] connect_exception
        at org.elasticsearch.transport.TcpTransport$ChannelsConnectedListener.onFailure(TcpTransport.java:1309) ~[elasticsearch-6.8.1.jar:6.8.1]
        at org.elasticsearch.action.ActionListener.lambda$toBiConsumer$2(ActionListener.java:100) ~[elasticsearch-6.8.1.jar:6.8.1]
        at org.elasticsearch.common.concurrent.CompletableContext.lambda$addListener$0(CompletableContext.java:42) ~[elasticsearch-core-6.8.1.jar:6.8.1]
        at java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:760) ~[?:1.8.0_212]
        at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:736) ~[?:1.8.0_212]
        at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:474) ~[?:1.8.0_212]
        at java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:1977) ~[?:1.8.0_212]
        at org.elasticsearch.common.concurrent.CompletableContext.completeExceptionally(CompletableContext.java:57) ~[elasticsearch-core-6.8.1.jar:6.8.1]
        at org.elasticsearch.transport.MockTcpTransport.lambda$initiateChannel$0(MockTcpTransport.java:195) ~[framework-6.8.1.jar:6.8.1]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) ~[?:1.8.0_212]
        at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~[?:1.8.0_212]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_212]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_212]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_212]
Caused by: java.net.ConnectException: Connection refused (Connection refused)
        at java.net.PlainSocketImpl.socketConnect(Native Method) ~[?:1.8.0_212]
        at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:350) ~[?:1.8.0_212]
        at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:206) ~[?:1.8.0_212]
        at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:188) ~[?:1.8.0_212]
        at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392) ~[?:1.8.0_212]
        at java.net.Socket.connect(Socket.java:589) ~[?:1.8.0_212]
        at org.elasticsearch.mocksocket.MockSocket.access$101(MockSocket.java:32) ~[mocksocket-1.2.jar:?]
        at org.elasticsearch.mocksocket.MockSocket.lambda$connect$0(MockSocket.java:66) ~[mocksocket-1.2.jar:?]
        at java.security.AccessController.doPrivileged(Native Method) ~[?:1.8.0_212]
        at org.elasticsearch.mocksocket.MockSocket.connect(MockSocket.java:65) ~[mocksocket-1.2.jar:?]
        at org.elasticsearch.mocksocket.MockSocket.connect(MockSocket.java:59) ~[mocksocket-1.2.jar:?]
        at org.elasticsearch.transport.MockTcpTransport.lambda$initiateChannel$0(MockTcpTransport.java:190) ~[framework-6.8.1.jar:6.8.1]
        ... 5 more
[2019-06-21T18:12:58,881][INFO ][o.e.e.NodeEnvironment    ] [testThatIndexingResultsInMonitoring] using [1] data paths, mounts [[/ (/dev/sda1)]], net usable_space [7.6gb], net total_space [29.3gb], types [ext4]
[2019-06-21T18:12:58,889][INFO ][o.e.e.NodeEnvironment    ] [testThatIndexingResultsInMonitoring] heap size [1.2gb], compressed ordinary object pointers [true]
[2019-06-21T18:12:58,895][INFO ][o.e.n.Node               ] [testThatIndexingResultsInMonitoring] node name [node_sm0], node ID [jDkU3_Y6TQq9nWYRfemB2w]
[2019-06-21T18:12:58,913][INFO ][o.e.n.Node               ] [testThatIndexingResultsInMonitoring] version[6.8.1], pid[14254], build[unknown/unknown/1fad4e1/2019-06-18T13:16:52.517138Z], OS[Linux/4.18.0-20-generic/amd64], JVM[Oracle Corporation/OpenJDK 64-Bit Server VM/1.8.0_212/25.212-b03]
[2019-06-21T18:12:58,921][INFO ][o.e.n.Node               ] [testThatIndexingResultsInMonitoring] JVM arguments []
[2019-06-21T18:12:58,923][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] no modules loaded
[2019-06-21T18:12:58,923][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [com.automattic.elasticsearch.plugin.StatsdPlugin]
[2019-06-21T18:12:58,924][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.test.ESIntegTestCase$AssertActionNamePlugin]
[2019-06-21T18:12:58,945][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.test.ESIntegTestCase$TestSeedPlugin]
[2019-06-21T18:12:58,945][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.test.discovery.TestZenDiscovery$TestPlugin]
[2019-06-21T18:12:58,946][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.transport.MockTcpTransportPlugin]
[2019-06-21T18:12:59,045][INFO ][o.e.d.DiscoveryModule    ] [testThatIndexingResultsInMonitoring] using discovery type [test-zen] and host providers [settings, file]
[2019-06-21T18:12:59,134][INFO ][o.e.n.Node               ] [testThatIndexingResultsInMonitoring] initialized
[2019-06-21T18:12:59,165][INFO ][o.e.n.Node               ] [integ_6] starting ...
[2019-06-21T18:12:59,173][INFO ][c.a.e.s.StatsdService    ] [integ_6] StatsD reporting triggered every [1s] to host [localhost:12345] with metric prefix [myhost0]
[2019-06-21T18:12:59,192][INFO ][c.a.e.s.StatsdService    ] [node_sm0] Cluster state not set yet. Looping...
[2019-06-21T18:12:59,203][INFO ][c.a.e.s.StatsdService    ] [node_sm0] Cluster state not set yet. Looping...
[2019-06-21T18:12:59,215][INFO ][c.a.e.s.StatsdService    ] [node_sm0] Cluster state not set yet. Looping...
[2019-06-21T18:12:59,219][INFO ][o.e.t.TransportService   ] [integ_6] publish_address {127.0.0.1:43971}, bound_addresses {[::1]:38709}, {127.0.0.1:43971}
[2019-06-21T18:12:59,295][INFO ][o.e.t.d.MockZenPing      ] [node_sm0] pinging using mock zen ping
[2019-06-21T18:12:59,342][INFO ][o.e.c.s.MasterService    ] [node_sm0] zen-disco-elected-as-master ([0] nodes joined), reason: new_master {node_sm0}{jDkU3_Y6TQq9nWYRfemB2w}{bhWelYYYTwyX5IHh4obOlA}{127.0.0.1}{127.0.0.1:43971}
[2019-06-21T18:12:59,358][INFO ][o.e.c.s.ClusterApplierService] [node_sm0] new_master {node_sm0}{jDkU3_Y6TQq9nWYRfemB2w}{bhWelYYYTwyX5IHh4obOlA}{127.0.0.1}{127.0.0.1:43971}, reason: apply cluster state (from master [master {node_sm0}{jDkU3_Y6TQq9nWYRfemB2w}{bhWelYYYTwyX5IHh4obOlA}{127.0.0.1}{127.0.0.1:43971} committed version [1] source [zen-disco-elected-as-master ([0] nodes joined)]])
[2019-06-21T18:12:59,400][INFO ][o.e.n.Node               ] [integ_6] started
[2019-06-21T18:12:59,450][INFO ][o.e.g.GatewayService     ] [node_sm0] recovered [0] indices into cluster_state
[2019-06-21T18:12:59,455][INFO ][o.e.c.s.MasterService    ] [node_sm0] zen-disco-node-join[{node_sd3}{5wqF7w5hSXS16Fj3rfBSdg}{TsK19QuhTQmY3CWbf_Bj8Q}{127.0.0.1}{127.0.0.1:45247}], reason: added {{node_sd3}{5wqF7w5hSXS16Fj3rfBSdg}{TsK19QuhTQmY3CWbf_Bj8Q}{127.0.0.1}{127.0.0.1:45247},}
[2019-06-21T18:12:59,464][INFO ][o.e.c.s.ClusterApplierService] [node_sd3] master {new {node_sm0}{jDkU3_Y6TQq9nWYRfemB2w}{bhWelYYYTwyX5IHh4obOlA}{127.0.0.1}{127.0.0.1:43971}}, removed {{node_s4}{jDkU3_Y6TQq9nWYRfemB2w}{d3mjsm6ZT6S53HfKdhMt5A}{127.0.0.1}{127.0.0.1:38179},{node_sd2}{Uh7CwNsmRUezdtRGOKrfEg}{MjIDZuwFRM65Mwd1ETh9vQ}{127.0.0.1}{127.0.0.1:37043},{node_sd1}{Adp5TIalTH6GZrVGvUi5Ww}{txvJoGO7SYS9cUrjeBWLLQ}{127.0.0.1}{127.0.0.1:45319},}, added {{node_sm0}{jDkU3_Y6TQq9nWYRfemB2w}{bhWelYYYTwyX5IHh4obOlA}{127.0.0.1}{127.0.0.1:43971},}, reason: apply cluster state (from master [master {node_sm0}{jDkU3_Y6TQq9nWYRfemB2w}{bhWelYYYTwyX5IHh4obOlA}{127.0.0.1}{127.0.0.1:43971} committed version [3]])
[2019-06-21T18:12:59,476][INFO ][o.e.c.s.ClusterApplierService] [node_sm0] added {{node_sd3}{5wqF7w5hSXS16Fj3rfBSdg}{TsK19QuhTQmY3CWbf_Bj8Q}{127.0.0.1}{127.0.0.1:45247},}, reason: apply cluster state (from master [master {node_sm0}{jDkU3_Y6TQq9nWYRfemB2w}{bhWelYYYTwyX5IHh4obOlA}{127.0.0.1}{127.0.0.1:43971} committed version [3] source [zen-disco-node-join[{node_sd3}{5wqF7w5hSXS16Fj3rfBSdg}{TsK19QuhTQmY3CWbf_Bj8Q}{127.0.0.1}{127.0.0.1:45247}]]])
[2019-06-21T18:12:59,482][INFO ][o.e.c.s.MasterService    ] [node_sm0] zen-disco-node-join[{node_sd1}{Adp5TIalTH6GZrVGvUi5Ww}{txvJoGO7SYS9cUrjeBWLLQ}{127.0.0.1}{127.0.0.1:45319}, {node_sd2}{Uh7CwNsmRUezdtRGOKrfEg}{MjIDZuwFRM65Mwd1ETh9vQ}{127.0.0.1}{127.0.0.1:37043}], reason: added {{node_sd1}{Adp5TIalTH6GZrVGvUi5Ww}{txvJoGO7SYS9cUrjeBWLLQ}{127.0.0.1}{127.0.0.1:45319},{node_sd2}{Uh7CwNsmRUezdtRGOKrfEg}{MjIDZuwFRM65Mwd1ETh9vQ}{127.0.0.1}{127.0.0.1:37043},}
[2019-06-21T18:12:59,486][INFO ][o.e.c.s.ClusterApplierService] [node_sd2] master {new {node_sm0}{jDkU3_Y6TQq9nWYRfemB2w}{bhWelYYYTwyX5IHh4obOlA}{127.0.0.1}{127.0.0.1:43971}}, removed {{node_s4}{jDkU3_Y6TQq9nWYRfemB2w}{d3mjsm6ZT6S53HfKdhMt5A}{127.0.0.1}{127.0.0.1:38179},}, added {{node_sm0}{jDkU3_Y6TQq9nWYRfemB2w}{bhWelYYYTwyX5IHh4obOlA}{127.0.0.1}{127.0.0.1:43971},}, reason: apply cluster state (from master [master {node_sm0}{jDkU3_Y6TQq9nWYRfemB2w}{bhWelYYYTwyX5IHh4obOlA}{127.0.0.1}{127.0.0.1:43971} committed version [4]])
[2019-06-21T18:12:59,486][INFO ][o.e.c.s.ClusterApplierService] [node_sd1] master {new {node_sm0}{jDkU3_Y6TQq9nWYRfemB2w}{bhWelYYYTwyX5IHh4obOlA}{127.0.0.1}{127.0.0.1:43971}}, removed {{node_s4}{jDkU3_Y6TQq9nWYRfemB2w}{d3mjsm6ZT6S53HfKdhMt5A}{127.0.0.1}{127.0.0.1:38179},}, added {{node_sm0}{jDkU3_Y6TQq9nWYRfemB2w}{bhWelYYYTwyX5IHh4obOlA}{127.0.0.1}{127.0.0.1:43971},}, reason: apply cluster state (from master [master {node_sm0}{jDkU3_Y6TQq9nWYRfemB2w}{bhWelYYYTwyX5IHh4obOlA}{127.0.0.1}{127.0.0.1:43971} committed version [4]])
[2019-06-21T18:12:59,508][INFO ][o.e.c.s.ClusterApplierService] [node_sd3] added {{node_sd1}{Adp5TIalTH6GZrVGvUi5Ww}{txvJoGO7SYS9cUrjeBWLLQ}{127.0.0.1}{127.0.0.1:45319},{node_sd2}{Uh7CwNsmRUezdtRGOKrfEg}{MjIDZuwFRM65Mwd1ETh9vQ}{127.0.0.1}{127.0.0.1:37043},}, reason: apply cluster state (from master [master {node_sm0}{jDkU3_Y6TQq9nWYRfemB2w}{bhWelYYYTwyX5IHh4obOlA}{127.0.0.1}{127.0.0.1:43971} committed version [4]])
[2019-06-21T18:12:59,552][INFO ][o.e.c.s.ClusterApplierService] [node_sm0] added {{node_sd1}{Adp5TIalTH6GZrVGvUi5Ww}{txvJoGO7SYS9cUrjeBWLLQ}{127.0.0.1}{127.0.0.1:45319},{node_sd2}{Uh7CwNsmRUezdtRGOKrfEg}{MjIDZuwFRM65Mwd1ETh9vQ}{127.0.0.1}{127.0.0.1:37043},}, reason: apply cluster state (from master [master {node_sm0}{jDkU3_Y6TQq9nWYRfemB2w}{bhWelYYYTwyX5IHh4obOlA}{127.0.0.1}{127.0.0.1:43971} committed version [4] source [zen-disco-node-join[{node_sd1}{Adp5TIalTH6GZrVGvUi5Ww}{txvJoGO7SYS9cUrjeBWLLQ}{127.0.0.1}{127.0.0.1:45319}, {node_sd2}{Uh7CwNsmRUezdtRGOKrfEg}{MjIDZuwFRM65Mwd1ETh9vQ}{127.0.0.1}{127.0.0.1:37043}]]])
[2019-06-21T18:12:59,593][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] no modules loaded
[2019-06-21T18:12:59,594][INFO ][o.e.p.PluginsService     ] [testThatIndexingResultsInMonitoring] loaded plugin [org.elasticsearch.transport.MockTcpTransportPlugin]
[2019-06-21T18:12:59,808][INFO ][o.e.c.m.MetaDataIndexTemplateService] [node_sm0] adding template [random_index_template] for index patterns [*]
[2019-06-21T18:12:59,876][INFO ][c.a.e.s.t.StatsdPluginIntegrationTest] [testThatIndexingResultsInMonitoring] [StatsdPluginIntegrationTest#testThatIndexingResultsInMonitoring]: all set up test
[2019-06-21T18:12:59,877][INFO ][c.a.e.s.t.StatsdPluginIntegrationTest] [testThatIndexingResultsInMonitoring] Creating index 09f6be
[2019-06-21T18:12:59,878][INFO ][c.a.e.s.t.StatsdPluginIntegrationTest] [testThatIndexingResultsInMonitoring] using custom data_path for index: [nafvCvMyBm]
[2019-06-21T18:12:59,898][INFO ][o.e.c.m.MetaDataCreateIndexService] [node_sm0] [09f6be] creating index, cause [api], templates [random_index_template], shards [4]/[1], mappings []
[2019-06-21T18:13:00,271][INFO ][o.e.c.m.MetaDataMappingService] [node_sm0] [09f6be/LN2UhNXkQ0qj3w5S-2dikA] create_mapping [4f7e10]
[2019-06-21T18:13:01,086][INFO ][o.e.c.r.a.AllocationService] [node_sm0] Cluster health status changed from [YELLOW] to [GREEN] (reason: [shards started [[09f6be][2], [09f6be][0]] ...]).
[2019-06-21T18:13:04,468][INFO ][c.a.e.s.t.StatsdPluginIntegrationTest] [testThatIndexingResultsInMonitoring] [StatsdPluginIntegrationTest#testThatIndexingResultsInMonitoring]: cleaning up after test
[2019-06-21T18:13:04,568][INFO ][o.e.c.m.MetaDataDeleteIndexService] [node_sm0] [09f6be/LN2UhNXkQ0qj3w5S-2dikA] deleting index
[2019-06-21T18:13:04,712][INFO ][o.e.c.m.MetaDataIndexTemplateService] [node_sm0] removing template [random_index_template]
[2019-06-21T18:13:04,724][INFO ][c.a.e.s.t.StatsdPluginIntegrationTest] [testThatIndexingResultsInMonitoring] [StatsdPluginIntegrationTest#testThatIndexingResultsInMonitoring]: cleaned up after test
[2019-06-21T18:13:04,725][INFO ][c.a.e.s.t.StatsdPluginIntegrationTest] [testThatIndexingResultsInMonitoring] after test
Waiting for cleanup
java.net.SocketException: Socket closed
        at java.net.PlainDatagramSocketImpl.peekData(Native Method)
        at java.net.DatagramSocket.receive(DatagramSocket.java:743)
        at com.automattic.elasticsearch.statsd.test.StatsdMockServer.run(StatsdMockServer.java:40)
[2019-06-21T18:13:14,741][INFO ][o.e.n.Node               ] [suite] stopping ...
[2019-06-21T18:13:14,748][INFO ][o.e.c.s.MasterService    ] [node_sm0] zen-disco-node-left({node_sd1}{Adp5TIalTH6GZrVGvUi5Ww}{txvJoGO7SYS9cUrjeBWLLQ}{127.0.0.1}{127.0.0.1:45319}), reason(left)[{node_sd1}{Adp5TIalTH6GZrVGvUi5Ww}{txvJoGO7SYS9cUrjeBWLLQ}{127.0.0.1}{127.0.0.1:45319} left], reason: removed {{node_sd1}{Adp5TIalTH6GZrVGvUi5Ww}{txvJoGO7SYS9cUrjeBWLLQ}{127.0.0.1}{127.0.0.1:45319},}
[2019-06-21T18:13:14,750][INFO ][o.e.c.s.ClusterApplierService] [node_sd2] removed {{node_sd1}{Adp5TIalTH6GZrVGvUi5Ww}{txvJoGO7SYS9cUrjeBWLLQ}{127.0.0.1}{127.0.0.1:45319},}, reason: apply cluster state (from master [master {node_sm0}{jDkU3_Y6TQq9nWYRfemB2w}{bhWelYYYTwyX5IHh4obOlA}{127.0.0.1}{127.0.0.1:43971} committed version [15]])
[2019-06-21T18:13:14,758][INFO ][o.e.c.s.ClusterApplierService] [node_sd3] removed {{node_sd1}{Adp5TIalTH6GZrVGvUi5Ww}{txvJoGO7SYS9cUrjeBWLLQ}{127.0.0.1}{127.0.0.1:45319},}, reason: apply cluster state (from master [master {node_sm0}{jDkU3_Y6TQq9nWYRfemB2w}{bhWelYYYTwyX5IHh4obOlA}{127.0.0.1}{127.0.0.1:43971} committed version [15]])
[2019-06-21T18:13:14,761][INFO ][o.e.c.s.ClusterApplierService] [node_sm0] removed {{node_sd1}{Adp5TIalTH6GZrVGvUi5Ww}{txvJoGO7SYS9cUrjeBWLLQ}{127.0.0.1}{127.0.0.1:45319},}, reason: apply cluster state (from master [master {node_sm0}{jDkU3_Y6TQq9nWYRfemB2w}{bhWelYYYTwyX5IHh4obOlA}{127.0.0.1}{127.0.0.1:43971} committed version [15] source [zen-disco-node-left({node_sd1}{Adp5TIalTH6GZrVGvUi5Ww}{txvJoGO7SYS9cUrjeBWLLQ}{127.0.0.1}{127.0.0.1:45319}), reason(left)[{node_sd1}{Adp5TIalTH6GZrVGvUi5Ww}{txvJoGO7SYS9cUrjeBWLLQ}{127.0.0.1}{127.0.0.1:45319} left]]])
[2019-06-21T18:13:14,767][INFO ][c.a.e.s.StatsdService    ] [suite] StatsD reporter stopped
[2019-06-21T18:13:14,767][ERROR][c.a.e.s.StatsdService    ] [node_sd1] Exiting StatsdReporterThread
[2019-06-21T18:13:14,768][INFO ][o.e.n.Node               ] [suite] stopped
[2019-06-21T18:13:14,768][INFO ][o.e.n.Node               ] [suite] closing ...
[2019-06-21T18:13:14,775][INFO ][o.e.n.Node               ] [suite] closed
[2019-06-21T18:13:14,779][INFO ][o.e.n.Node               ] [suite] stopping ...
[2019-06-21T18:13:14,783][INFO ][o.e.c.s.MasterService    ] [node_sm0] zen-disco-node-left({node_sd2}{Uh7CwNsmRUezdtRGOKrfEg}{MjIDZuwFRM65Mwd1ETh9vQ}{127.0.0.1}{127.0.0.1:37043}), reason(left)[{node_sd2}{Uh7CwNsmRUezdtRGOKrfEg}{MjIDZuwFRM65Mwd1ETh9vQ}{127.0.0.1}{127.0.0.1:37043} left], reason: removed {{node_sd2}{Uh7CwNsmRUezdtRGOKrfEg}{MjIDZuwFRM65Mwd1ETh9vQ}{127.0.0.1}{127.0.0.1:37043},}
[2019-06-21T18:13:14,785][INFO ][o.e.c.s.ClusterApplierService] [node_sd3] removed {{node_sd2}{Uh7CwNsmRUezdtRGOKrfEg}{MjIDZuwFRM65Mwd1ETh9vQ}{127.0.0.1}{127.0.0.1:37043},}, reason: apply cluster state (from master [master {node_sm0}{jDkU3_Y6TQq9nWYRfemB2w}{bhWelYYYTwyX5IHh4obOlA}{127.0.0.1}{127.0.0.1:43971} committed version [16]])
[2019-06-21T18:13:14,788][INFO ][o.e.c.s.ClusterApplierService] [node_sm0] removed {{node_sd2}{Uh7CwNsmRUezdtRGOKrfEg}{MjIDZuwFRM65Mwd1ETh9vQ}{127.0.0.1}{127.0.0.1:37043},}, reason: apply cluster state (from master [master {node_sm0}{jDkU3_Y6TQq9nWYRfemB2w}{bhWelYYYTwyX5IHh4obOlA}{127.0.0.1}{127.0.0.1:43971} committed version [16] source [zen-disco-node-left({node_sd2}{Uh7CwNsmRUezdtRGOKrfEg}{MjIDZuwFRM65Mwd1ETh9vQ}{127.0.0.1}{127.0.0.1:37043}), reason(left)[{node_sd2}{Uh7CwNsmRUezdtRGOKrfEg}{MjIDZuwFRM65Mwd1ETh9vQ}{127.0.0.1}{127.0.0.1:37043} left]]])
[2019-06-21T18:13:14,803][INFO ][c.a.e.s.StatsdService    ] [suite] StatsD reporter stopped
[2019-06-21T18:13:14,803][ERROR][c.a.e.s.StatsdService    ] [node_sd2] Exiting StatsdReporterThread
[2019-06-21T18:13:14,803][INFO ][o.e.n.Node               ] [suite] stopped
[2019-06-21T18:13:14,804][INFO ][o.e.n.Node               ] [suite] closing ...
[2019-06-21T18:13:14,811][INFO ][o.e.n.Node               ] [suite] closed
[2019-06-21T18:13:14,816][INFO ][o.e.n.Node               ] [suite] stopping ...
[2019-06-21T18:13:14,834][INFO ][o.e.c.s.MasterService    ] [node_sm0] zen-disco-node-left({node_sd3}{5wqF7w5hSXS16Fj3rfBSdg}{TsK19QuhTQmY3CWbf_Bj8Q}{127.0.0.1}{127.0.0.1:45247}), reason(left)[{node_sd3}{5wqF7w5hSXS16Fj3rfBSdg}{TsK19QuhTQmY3CWbf_Bj8Q}{127.0.0.1}{127.0.0.1:45247} left], reason: removed {{node_sd3}{5wqF7w5hSXS16Fj3rfBSdg}{TsK19QuhTQmY3CWbf_Bj8Q}{127.0.0.1}{127.0.0.1:45247},}
[2019-06-21T18:13:14,836][INFO ][o.e.c.s.ClusterApplierService] [node_sm0] removed {{node_sd3}{5wqF7w5hSXS16Fj3rfBSdg}{TsK19QuhTQmY3CWbf_Bj8Q}{127.0.0.1}{127.0.0.1:45247},}, reason: apply cluster state (from master [master {node_sm0}{jDkU3_Y6TQq9nWYRfemB2w}{bhWelYYYTwyX5IHh4obOlA}{127.0.0.1}{127.0.0.1:43971} committed version [17] source [zen-disco-node-left({node_sd3}{5wqF7w5hSXS16Fj3rfBSdg}{TsK19QuhTQmY3CWbf_Bj8Q}{127.0.0.1}{127.0.0.1:45247}), reason(left)[{node_sd3}{5wqF7w5hSXS16Fj3rfBSdg}{TsK19QuhTQmY3CWbf_Bj8Q}{127.0.0.1}{127.0.0.1:45247} left]]])
[2019-06-21T18:13:14,871][INFO ][c.a.e.s.StatsdService    ] [suite] StatsD reporter stopped
[2019-06-21T18:13:14,871][INFO ][o.e.n.Node               ] [suite] stopped
[2019-06-21T18:13:14,872][INFO ][o.e.n.Node               ] [suite] closing ...
[2019-06-21T18:13:14,876][ERROR][c.a.e.s.StatsdService    ] [node_sd3] Exiting StatsdReporterThread
[2019-06-21T18:13:14,882][INFO ][o.e.n.Node               ] [suite] closed
[2019-06-21T18:13:14,887][INFO ][o.e.n.Node               ] [suite] stopping ...
[2019-06-21T18:13:14,901][ERROR][c.a.e.s.StatsdService    ] [node_sm0] Exiting StatsdReporterThread
[2019-06-21T18:13:14,902][INFO ][c.a.e.s.StatsdService    ] [suite] StatsD reporter stopped
[2019-06-21T18:13:14,905][INFO ][o.e.n.Node               ] [suite] stopped
[2019-06-21T18:13:14,907][INFO ][o.e.n.Node               ] [suite] closing ...
[2019-06-21T18:13:14,933][INFO ][o.e.n.Node               ] [suite] closed
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 38.886 sec

Results :

Tests run: 2, Failures: 0, Errors: 0, Skipped: 0

[INFO] 
[INFO] --- maven-jar-plugin:2.4:jar (default-jar) @ elasticsearch-statsd ---
[INFO] Building jar: /home/ph/projects/elasticsearch-statsd-plugin/target/elasticsearch-statsd-6.8.1.0.jar
[INFO] 
[INFO] --- maven-assembly-plugin:2.3:single (default) @ elasticsearch-statsd ---
[INFO] Reading assembly descriptor: /home/ph/projects/elasticsearch-statsd-plugin/src/main/assemblies/plugin.xml
[WARNING] The following patterns were never triggered in this artifact exclusion filter:
o  'org.elasticsearch:elasticsearch'

[INFO] Building zip: /home/ph/projects/elasticsearch-statsd-plugin/target/releases/elasticsearch-statsd-6.8.1.0.zip
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  55.107 s
[INFO] Finished at: 2019-06-21T18:13:18+03:00
[INFO] ------------------------------------------------------------------------
```